### PR TITLE
Add a method to renew ntp sync

### DIFF
--- a/modules/camera/include/ifm3d/camera/camera.h
+++ b/modules/camera/include/ifm3d/camera/camera.h
@@ -421,6 +421,11 @@ namespace ifm3d
     virtual void SetCurrentTime(int epoch_secs = -1);
 
     /**
+     * Ask the device to retry to sync time with configured ntp servers
+     */
+    virtual void RenewNTP();
+
+    /**
      * Sets the camera configuration back to the state in which it shipped from
      * the ifm factory.
      */

--- a/modules/camera/src/libifm3d_camera/camera.cpp
+++ b/modules/camera/src/libifm3d_camera/camera.cpp
@@ -539,6 +539,15 @@ ifm3d::Camera::SetCurrentTime(int epoch_secs)
     [this,epoch_secs]() { this->pImpl->SetCurrentTime(epoch_secs); });
 }
 
+void
+ifm3d::Camera::RenewNTP()
+{
+  this->pImpl->WrapInEditSession([this]()
+    {
+      this->pImpl->SaveTime();
+    });
+}
+
 std::vector<std::uint8_t>
 ifm3d::Camera::ExportIFMConfig()
 {


### PR DESCRIPTION
For our robot, we needed a way to trigger a NTP renew because our NTP server is not available when the camera boot.

The first solution we found was to disable and enable again the time synchronization but it was taking 6 seconds per camera. But this solution slows down a lot the initialization process when you have 8 cameras.
```
camera->FromJSONStr("{\"Time\": {\"SynchronizationActivated\": \"false\"}}");
camera->FromJSONStr("{\"Time\": {\"SynchronizationActivated\": \"true\"}}");
```

So this PR add `Camera::RenewNTP()` which is basically a simple `Camera::Impl::SaveTime()` to trigger a new time sync.