### PR TITLE
[0.15.1] Minor updates to allow cross-compiling ifm3d for the O3D3XX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 cmake_policy(SET CMP0048 NEW)
 # Manage version number here: Major.Minor.Patch (we don't use "tweak")
-project(IFM3D VERSION 0.15.0 LANGUAGES CXX)
+project(IFM3D VERSION 0.15.1 LANGUAGES CXX)
 set(GIT_PROJECT_NAME "ifm3d")
 
 # Make our cmake functions accessible

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+## Changes between ifm3d 0.15.0 and 0.15.1
+* Minor updates to allow for cross-compiling ifm3d for the O3D3XX
+
 ## Changes between ifm3d 0.14.1 and 0.15.0
 * Added Interface for getting json_model from O3D3xx devices.
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Current Revision
     <th>Notes</th>
   </tr>
   <tr>
-    <td>0.15.0</td>
+    <td>0.15.1</td>
     <td>1.6.2114, 1.8.769, 1.20.1138, 1.23.1506, 1.23.1522, 1.23.2848,
     1.25.4073, 1.30.4123</td>
     <td>1.0.111, 1.0.122, 1.0.126</td>
     <td>16.04,18.04</td>
-    <td>Interface added to grab json_model data of application output</td>
+    <td>Minor updates to allow for cross-compiling ifm3d for the O3D3XX</td>
   </tr>
 </table>
 

--- a/cmake/toolchains/o3d303.cmake
+++ b/cmake/toolchains/o3d303.cmake
@@ -1,5 +1,5 @@
 #
-# Toolchain for cross-building imf3d for the O3D303 camera.
+# Toolchain for cross-building imf3d for the O3D3xx camera.
 #
 # NOTE: For this file to work, you must first:
 # source /opt/poky/1.8.1/environment-setup-armv7ahf-vfp-neon-poky-linux-gnueabi

--- a/cmake/toolchains/o3d303.cmake
+++ b/cmake/toolchains/o3d303.cmake
@@ -1,0 +1,22 @@
+#
+# Toolchain for cross-building imf3d for the O3D303 camera.
+#
+# NOTE: For this file to work, you must first:
+# source /opt/poky/1.8.1/environment-setup-armv7ahf-vfp-neon-poky-linux-gnueabi
+#
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSROOT /opt/poky/1.8.1/sysroots/armv7ahf-vfp-neon-poky-linux-gnueabi)
+set(SYSROOT_CONTRIB /opt/poky/contrib)
+set(CMAKE_FIND_ROOT_PATH ${SYSROOT_CONTRIB} ${CMAKE_SYSROOT})
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+set(CMAKE_LIBRARY_PATH /lib
+                       /usr/lib
+                       /usr/lib/arm-linux-gnueabihf)
+
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "armhf")

--- a/doc/swcompat.md
+++ b/doc/swcompat.md
@@ -198,4 +198,12 @@ ifm3d Software Compatibility Matrix
     <td>16.04,18.04</td>
     <td>Interface added to grab json_model data of application output</td>
   </tr>
+  <tr>
+    <td>0.15.1</td>
+    <td>1.6.2114, 1.8.769, 1.20.1138, 1.23.1506, 1.23.1522, 1.23.2848,
+    1.25.4073</td>
+    <td>1.0.111, 1.0.122, 1.0.126</td>
+    <td>16.04,18.04</td>
+    <td>Minor updates to allow for cross-compiling ifm3d for the O3D3XX</td>
+  </tr>
 </table>

--- a/modules/camera/src/libifm3d_camera/CMakeLists.txt
+++ b/modules/camera/src/libifm3d_camera/CMakeLists.txt
@@ -1,7 +1,12 @@
 ################################################
 ## Bring in dependent projects
 ################################################
-if(NOT WIN32)
+
+# NOTE: The `FindXMLRPC.cmake` file does not respect cross-compilation
+# environments or windows builds. so, we make the assumption the includes are
+# in a standard directory in your sysroot (for cross compiling) or included via
+# a custom xmlrpc-c library on Windows (See Windows build instructions).
+if (NOT WIN32 AND NOT CMAKE_CROSSCOMPILING)
   find_package(XMLRPC REQUIRED c++ client)
 endif()
 

--- a/modules/camera/src/libifm3d_camera/camera.cpp
+++ b/modules/camera/src/libifm3d_camera/camera.cpp
@@ -114,7 +114,7 @@ const unsigned int ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_PATCH = 0;
 //================================================
 std::unordered_map<std::string,
                    std::unordered_map<std::string, bool> >
-RO_LUT =
+RO_LUT=
   {
     {"Device",
      {
@@ -172,11 +172,13 @@ RO_LUT =
 
     {"SpatialFilter",
      {
+       {}
      }
     },
 
     {"TemporalFilter",
      {
+      {}
      }
     }
   };


### PR DESCRIPTION
One C++11 compat issue (copy-init list for empty maps instead of init-list).

Change to not use FindXMLRPC.cmake module when cross compiling.

Created toolchain file (copied from libo3d3xx)