### PR TITLE
Update frame_grabber_impl.hpp

### DIFF
--- a/modules/framegrabber/src/libifm3d_framegrabber/frame_grabber_impl.hpp
+++ b/modules/framegrabber/src/libifm3d_framegrabber/frame_grabber_impl.hpp
@@ -352,6 +352,12 @@ ifm3d::FrameGrabber::Impl::WaitForFrame(
       return false;
     }
 
+  if (this->front_buffer_.empty())
+  {
+    VLOG(IFM3D_TRACE)
+      << "Image buffer is empty";
+    return false;
+  }
   // if (copy_buff)
   //   {
   //     std::size_t sz = this->front_buffer_.size();


### PR DESCRIPTION
On Windows, wait_for() can return bogus no_timeout status. Added check for empty buffer to prevent exception being thrown.