### PR TITLE
Add docs and fixes for cross compile

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior. For example:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Output/Screenshots**
+If applicable, add console output and/or screenshots to help explain your problem.
+
+**Minimal Working Example**
+If applicable/possible, please provide a [minimal working example](https://stackoverflow.com/help/minimal-reproducible-example) which demonstrates the problem and can be run standalone.
+
+**Configuration/Environment (please complete the following information):**
+ - OS: [e.g. Ubuntu 18.04, Windows 10]
+ -  ifm3d version: [e.g. 0.14.0]
+ - using ROS: [yes/no]
+
+**Camera Configuration**
+Please include the output of `ifm3d dump`
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -26,6 +26,15 @@ If applicable, add console output and/or screenshots to help explain your proble
 **Minimal Working Example**
 If applicable/possible, please provide a [minimal working example](https://stackoverflow.com/help/minimal-reproducible-example) which demonstrates the problem and can be run standalone.
 
+```
+#include <iostream>
+int main()
+{
+  std::cout << "Hello World!" << std::endl;
+  return 0;
+}
+```
+
 **Configuration/Environment (please complete the following information):**
  - OS: [e.g. Ubuntu 18.04, Windows 10]
  -  ifm3d version: [e.g. 0.14.0]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: proposal
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,10 @@
+---
+name: Question
+about: Ask a question about ifm3d
+title: ''
+labels: question
+assignees: ''
+
+---
+
+

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Installing the Software
 Binaries for ifm3d are available on a few supported platforms. Instructions for
 each now follow.
 
-### Linux
+### Linux (x64)
 
 #### Configure the ifm apt server
 
@@ -165,9 +165,33 @@ source. Those instructions are located at the
 above will simply install the core `ifm3d` sensor interface and tools, linked
 properly against libraries in your ROS environment.
 
+### Linux (ARM64)
+
+We provide ARM64 binaries targeting Linux for Tegra (L4T), an NVIDIA
+distribution based on Ubuntu 18.04 for the Jetson Nano, TX1, TX2 and Xavier
+platforms. 
+
+```
+$ sudo sh -c 'echo "deb [arch=arm64] https://nexus.ifm.com/repository/ifm-robotics_ubuntu_bionic_arm64 bionic main" > /etc/apt/sources.list.d/ifm-robotics.list'
+$ sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 8AB59D3A2BD7B692
+$ sudo apt-get update
+$ sudo apt-get install ifm3d-camera \
+                       ifm3d-framegrabber \
+                       ifm3d-swupdater \
+                       ifm3d-image \
+                       ifm3d-opencv \
+                       ifm3d-pcicclient \
+                       ifm3d-tools \
+                       ifm3d-python \
+                       ifm3d-python3
+$ sudo apt-get install ifm3d-pcl-viewer
+```
+
 ### Windows
 
-Coming soon...
+Pre-built binaries are not yet available. For now we recommend manually
+compiling for the target MSVC/SDK versions according to the
+[building on windows](doc/windows.md) instructions.
 
 ### Other platforms
 

--- a/doc/cross_compiling.md
+++ b/doc/cross_compiling.md
@@ -1,0 +1,37 @@
+# Cross-compiling ifm3d
+
+One benefit of the CMake build system is the possibility to cross compile your code. To demonstrate this with ifm3d we use a Toolchain created with OpenEmbedded as a showcase
+
+
+# Installing a Toolchain
+
+Depending on your Toolchain provider this step might look different
+
+```
+$ chmod +x poky-glibc-i686-vantage-image-armv7ahf-vfp-neon-toolchain-qte-1.8.1.sh
+$ ./poky-glibc-i686-vantage-image-armv7ahf-vfp-neon-toolchain-qte-1.8.1.sh
+```
+
+# Using the Toolcahin
+
+```
+$ git clone https://github.com/ifm/ifm3d.git
+$ cd ifm3d/
+$ mkdir build
+$ source /opt/poky/1.8.1/environment-setup-armv7ahf-vfp-neon-poky-linux-gnueabi
+$ cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/o3d303.cmake -DCMAKE_INSTALL_PREFIX=../../oem-partition/ ..
+```
+The step ``source /opt/poky/1.8.1/environment-setup-armv7ahf-vfp-neon-poky-linux-gnueabi`` is necessary for the OpenEmbedded Toolchain to set all the needed Environment variables.
+
+The variable ``CMAKE_INSTALL_PREFIX`` may get handy when you plan to install the ifm3d library and tools to a specific location for an OEM deployment for example.
+To run the build you may have to adjust the argument of ``-j`` depending on the number of CPU cores available in your system
+
+```
+$ make -j8
+$ make install
+```
+
+# Caution
+
+Both the provided Toolchain file [cmake/toolchains/o3d303.cmake](cmake/toolchains/o3d303.cmake) and the instructions above are examples for the OEM workflow. Both maybe needs adjustments if you are planning to use a different type of set-up
+

--- a/modules/tools/contrib/CMakeLists.txt
+++ b/modules/tools/contrib/CMakeLists.txt
@@ -1,16 +1,18 @@
-if (UNIX)
-  file(COPY ${IFM3D_TOOLS_SOURCE_DIR}/contrib/ifm3d_completions.in
-    DESTINATION ${IFM3D_TOOLS_BINARY_DIR}
-    )
-  configure_file(
-    ${IFM3D_TOOLS_BINARY_DIR}/ifm3d_completions.in
-    ${IFM3D_TOOLS_BINARY_DIR}/ifm3d_completions
-    @ONLY
-    )
+if(NOT CMAKE_CROSSCOMPILING)
+  if (UNIX)
+    file(COPY ${IFM3D_TOOLS_SOURCE_DIR}/contrib/ifm3d_completions.in
+      DESTINATION ${IFM3D_TOOLS_BINARY_DIR}
+      )
+    configure_file(
+      ${IFM3D_TOOLS_BINARY_DIR}/ifm3d_completions.in
+      ${IFM3D_TOOLS_BINARY_DIR}/ifm3d_completions
+      @ONLY
+      )
 
-  install(
-    FILES ${IFM3D_TOOLS_BINARY_DIR}/ifm3d_completions
-    DESTINATION /etc/bash_completion.d
-    COMPONENT tools
-    )
+    install(
+      FILES ${IFM3D_TOOLS_BINARY_DIR}/ifm3d_completions
+      DESTINATION /etc/bash_completion.d
+      COMPONENT tools
+      )
+  endif()
 endif()


### PR DESCRIPTION
To provide OEMS a way of deploying code on an O3D3xx
this provides a documentation how to cross compile the
libs and tools.

It also provides a minor fix, to only install the bash completion
when not cross compiling.

Signed-off-by: Christian Ege <christian.ege@ifm.com>