### PR TITLE
Create a snapcraft.yaml file for building as a snap application

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,83 @@
+name: ifm3d
+base: core18
+adopt-info: ifm3d
+summary: Utilities for working with ifm 3D ToF cameras
+description: |
+  This package provides tools and utilities for working with the ifm O3D3XX and
+  O3X families of 3D time of flight depth cameras.
+
+  **ifm3d**
+
+  The ifm3d application is a command line utility for manipulating the state
+  of the cameras. It is distributed as part of the open source ifm3d library
+  hosted at https://github.com/ifm/ifm3d.
+
+  **ifm3d.viewer**
+
+  The ifm3d.viewer application is a simple GUI for viewing colorized depth
+  information from the camera. Source code available in the open source project
+  hosted at https://github.com/ifm/ifm3d-pcl-viewer.
+
+license: Apache-2.0
+confinement: strict
+
+parts:
+  ifm3d:
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version $(cat CMakeLists.txt | sed -ne 's/project(IFM3D VERSION .*\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')-$(git rev-parse --short HEAD)
+      if [[ $(git branch) == "master" ]]; then
+        snapcraftctl set-grade "stable"
+      else
+        snapcraftctl set-grade "devel"
+      fi
+    plugin: cmake
+    configflags:
+      - '-DCMAKE_INSTALL_PREFIX=/usr'
+      - '-DBUILD_TESTS=OFF'
+    source: .
+    build-packages:
+      - g++
+      - make
+      - cmake
+      - libboost-all-dev
+      - libcurl4-openssl-dev
+      - libgoogle-glog-dev
+      - libxmlrpc-c++8-dev
+      - libopencv-dev
+      - libpcl-dev
+    stage-packages:
+      - libgcc1
+      - libgoogle-glog0v5
+      - libcurl4
+      - libstdc++6
+      - libxmlrpc-c++8v5
+      - libxmlrpc-core-c3
+      - libboost-system1.65.1
+      - libboost-program-options1.65.1
+      - libopencv-core3.2
+  ifm3d-pcl-viewer:
+    plugin: cmake
+    source: https://github.com/ifm/ifm3d-pcl-viewer.git
+    source-type: git
+    configflags: ['-DCMAKE_INSTALL_PREFIX=/usr']
+    after: [ifm3d]
+    stage-packages:
+      - libgcc1
+      - libgoogle-glog0v5
+      - libstdc++6
+      - libboost-system1.65.1
+      - libpcl-common1.8
+      - libpcl-visualization1.8
+      - libvtk6.3
+
+apps:
+  ifm3d:
+    command: ifm3d
+    plugs: [network]
+  viewer:
+    command: ifm3d-pcl-viewer
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri
+      LIBGL_DRIVERS_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri
+    plugs: [network, x11, opengl]


### PR DESCRIPTION
Bundles `ifm3d` and `ifm3d-pcl-viewer` into a single snap package.

Automated CI/builds cannot be set up until this is merged to master. In the meantime, this package has been released in beta to the edge channel: https://snapcraft.io/ifm3d