### PR TITLE
Introduce clang-format rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,39 @@
+---
+BasedOnStyle: Mozilla
+AccessModifierOffset: '-2'
+AlignAfterOpenBracket: Align
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowShortBlocksOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AlwaysBreakAfterReturnType: AllDefinitions
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeColon
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    true
+  SplitEmptyFunction: false
+ColumnLimit: 79
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+Cpp11BracedListStyle: true
+IndentCaseLabels: false
+IndentPPDirectives: AfterHash
+NamespaceIndentation: All
+SortIncludes: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyBlock: true
+Standard: c++14

--- a/clang_format.py
+++ b/clang_format.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) ifm electronic gmbh
+#
+# THE PROGRAM IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND.
+
+# Provides functions to format C/C++ files using clang-format
+import sys
+assert sys.version_info > (3, 5), "python 3.5 or more required"
+import os
+import subprocess
+import re
+
+"""
+    Function to execute system command on console
+        Args:
+            command (string) : console command with parameters
+        Return :
+            standard output of command as a string
+"""
+def system_call(command):
+    p = subprocess.run(command, stdout=subprocess.PIPE)
+    return p.stdout.decode()
+
+# Extension and folders to be excludes from formatting
+apply_extensions = (".cxx",".cpp",".c", ".hxx", ".hh", ".cc", ".hpp", ".h")
+exclude_folders = ("third-party",".github","build","cmake","docker","snap",".git","cxxopts", "contrib")
+
+"""
+    Function runs the clang formatter on the files
+    with extension mention in  'apply_extensions' and
+    not in the folders mentioned in 'exclude_folders'
+
+    Return:
+        (bool) True if all files are formatted else
+               False.
+"""
+def clang_format():
+    try:
+        # walk all the folders from the current wotking directory
+        for root, dirs, files in os.walk(os.getcwd()):
+            # check if the folder is in excluded list
+            if os.path.split(root)[1] in exclude_folders :
+                files[:]=[]
+                dirs[:] = []
+            #loop over files
+            for file in files:
+                #check for file extension
+                if file.endswith(apply_extensions):
+                    os.system("clang-format -i -style=file " + os.path.join(root,file))
+                    #print(os.path.join(root,file))
+        return True
+    except:
+        print("Error with formatting file")
+"""
+    Function checks the version of the clang-formatter
+    available with the host system
+"""
+def get_clang_format_version():
+    ret = system_call (['clang-format', '--version'])
+    tokens = re.search("^(\w+-\w+) (\w+) ([0-9.]+).*",ret)
+    if tokens.group(1) == "clang-format" and tokens.group(2) == "version":
+        return int(tokens.group(3).replace(".", ""))
+    else:
+        print("error getting clang-format version")
+
+minimum_required_clang_format_version = 600
+
+#entry point
+if __name__ == "__main__":
+    if get_clang_format_version() >= minimum_required_clang_format_version:
+        if clang_format():
+            print("Done formatting files")
+    else :
+        print("minimum required clang-format version is 6.0.0")

--- a/modules/camera/include/ifm3d/camera/camera.h
+++ b/modules/camera/include/ifm3d/camera/camera.h
@@ -54,13 +54,19 @@ namespace ifm3d
   extern IFM3D_CAMERA_EXPORT const unsigned int O3D_TMP_PARAMS_SUPPORT_MINOR;
   extern IFM3D_CAMERA_EXPORT const unsigned int O3D_TMP_PARAMS_SUPPORT_PATCH;
 
-  extern IFM3D_CAMERA_EXPORT const unsigned int O3D_INTRINSIC_PARAM_SUPPORT_MAJOR;
-  extern IFM3D_CAMERA_EXPORT const unsigned int O3D_INTRINSIC_PARAM_SUPPORT_MINOR;
-  extern IFM3D_CAMERA_EXPORT const unsigned int O3D_INTRINSIC_PARAM_SUPPORT_PATCH;
+  extern IFM3D_CAMERA_EXPORT const unsigned int
+    O3D_INTRINSIC_PARAM_SUPPORT_MAJOR;
+  extern IFM3D_CAMERA_EXPORT const unsigned int
+    O3D_INTRINSIC_PARAM_SUPPORT_MINOR;
+  extern IFM3D_CAMERA_EXPORT const unsigned int
+    O3D_INTRINSIC_PARAM_SUPPORT_PATCH;
 
-  extern IFM3D_CAMERA_EXPORT const unsigned int O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_MAJOR;
-  extern IFM3D_CAMERA_EXPORT const unsigned int O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_MINOR;
-  extern IFM3D_CAMERA_EXPORT const unsigned int O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_PATCH;
+  extern IFM3D_CAMERA_EXPORT const unsigned int
+    O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_MAJOR;
+  extern IFM3D_CAMERA_EXPORT const unsigned int
+    O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_MINOR;
+  extern IFM3D_CAMERA_EXPORT const unsigned int
+    O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_PATCH;
 
   /**
    * Software interface to an ifm 3D camera
@@ -81,40 +87,70 @@ namespace ifm3d
      * Productive: the normal runtime firmware comes up
      * Recovery: allows you to flash new firmware
      */
-    enum class boot_mode : int { PRODUCTIVE = 0, RECOVERY = 1 };
+    enum class boot_mode : int
+    {
+      PRODUCTIVE = 0,
+      RECOVERY = 1
+    };
 
     /**
      * Camera operating modes: run (streaming pixel data), edit (configuring
      * the device/applications).
      */
-    enum class operating_mode : int { RUN = 0, EDIT = 1 };
+    enum class operating_mode : int
+    {
+      RUN = 0,
+      EDIT = 1
+    };
 
     /**
      * Image acquisition trigger modes
      */
-    enum class trigger_mode : int { FREE_RUN = 1, SW = 2 };
+    enum class trigger_mode : int
+    {
+      FREE_RUN = 1,
+      SW = 2
+    };
 
     /**
      * Import flags used when importing a Vision Assistant configuration
      */
-    enum class import_flags : int { GLOBAL = 0x1, NET = 0x2, APPS = 0x10 };
+    enum class import_flags : int
+    {
+      GLOBAL = 0x1,
+      NET = 0x2,
+      APPS = 0x10
+    };
 
     /**
      * Convenience constants for spatial filter types
      */
     enum class spatial_filter : int
-    { OFF = 0x0, MEDIAN = 0x1, MEAN = 0x2, BILATERAL = 0x3 };
+    {
+      OFF = 0x0,
+      MEDIAN = 0x1,
+      MEAN = 0x2,
+      BILATERAL = 0x3
+    };
 
     /**
      * Convenience constants for temporal filter types
      */
     enum class temporal_filter : int
-    { OFF = 0x0, MEAN = 0x1, ADAPTIVE_EXP = 0x2 };
+    {
+      OFF = 0x0,
+      MEAN = 0x1,
+      ADAPTIVE_EXP = 0x2
+    };
 
     /**
      * Convenient constants for median filter mask sizes
      */
-    enum class mfilt_mask_size : int { _3x3 = 0, _5x5 = 1};
+    enum class mfilt_mask_size : int
+    {
+      _3x3 = 0,
+      _5x5 = 1
+    };
 
     /**
      * Factory function for instantiating the proper subclass based on h/w
@@ -136,10 +172,10 @@ namespace ifm3d
      *                     with the sensor. Edit sessions allow for mutating
      *                     camera parameters and persisting those changes.
      */
-    static Ptr
-    MakeShared(const std::string& ip = ifm3d::DEFAULT_IP,
-               const std::uint16_t xmlrpc_port = ifm3d::DEFAULT_XMLRPC_PORT,
-               const std::string& password = ifm3d::DEFAULT_PASSWORD);
+    static Ptr MakeShared(
+      const std::string& ip = ifm3d::DEFAULT_IP,
+      const std::uint16_t xmlrpc_port = ifm3d::DEFAULT_XMLRPC_PORT,
+      const std::string& password = ifm3d::DEFAULT_PASSWORD);
 
     /**
      * Initializes the camera interface utilizing library defaults
@@ -281,8 +317,8 @@ namespace ifm3d
      * @param[in] mode The system mode to boot into upon restart of the sensor
      * @throw ifm3d::error_t upon error
      */
-    virtual void
-    Reboot(const boot_mode& mode = ifm3d::Camera::boot_mode::PRODUCTIVE);
+    virtual void Reboot(
+      const boot_mode& mode = ifm3d::Camera::boot_mode::PRODUCTIVE);
 
     /**
      * Returns the integer index of the active application. A negative number
@@ -341,7 +377,7 @@ namespace ifm3d
      *
      * @throw ifm3d::error_t upon error
      */
-     virtual std::vector<std::string> TraceLogs(int count);
+    virtual std::vector<std::string> TraceLogs(int count);
 
     /**
      * Delivers basic information about all applications stored on the device.
@@ -409,7 +445,7 @@ namespace ifm3d
      * @return The index of the new application.
      */
     virtual int CreateApplication(
-            const std::string& type = DEFAULT_APPLICATION_TYPE);
+      const std::string& type = DEFAULT_APPLICATION_TYPE);
 
     /**
      * Deletes the application at the specified index from the sensor.
@@ -587,13 +623,13 @@ namespace ifm3d
      * @param[in] idx An application index to put into edit mode prior to
      *                setting parameters.
      */
-    void FromJSON_(const json& j_curr,
-                   const json& j_new,
-                   std::function<void(const std::string&,
-                                      const std::string&)> SetFunc,
-                   std::function<void()> SaveFunc,
-                   const std::string& name,
-                   int idx = -1);
+    void FromJSON_(
+      const json& j_curr,
+      const json& j_new,
+      std::function<void(const std::string&, const std::string&)> SetFunc,
+      std::function<void()> SaveFunc,
+      const std::string& name,
+      int idx = -1);
 
     /**
      *  Implements the serialization of the camera state to JSON.

--- a/modules/camera/include/ifm3d/camera/camera_export.h
+++ b/modules/camera/include/ifm3d/camera/camera_export.h
@@ -7,7 +7,7 @@
 #  ifdef IFM3D_CAMERA_DLL_BUILD
 #    define IFM3D_CAMERA_EXPORT __declspec(dllexport)
 #  else
-#     define IFM3D_CAMERA_EXPORT __declspec(dllimport)
+#    define IFM3D_CAMERA_EXPORT __declspec(dllimport)
 #  endif
 #endif
 

--- a/modules/camera/include/ifm3d/camera/err.h
+++ b/modules/camera/include/ifm3d/camera/err.h
@@ -21,7 +21,6 @@
 #include <exception>
 #include <ifm3d/camera/camera_export.h>
 
-
 // library errors
 extern IFM3D_CAMERA_EXPORT const int IFM3D_NO_ERRORS;
 extern IFM3D_CAMERA_EXPORT const int IFM3D_XMLRPC_FAILURE;
@@ -40,10 +39,14 @@ extern IFM3D_CAMERA_EXPORT const int IFM3D_RECOVERY_CONNECTION_ERROR;
 extern IFM3D_CAMERA_EXPORT const int IFM3D_UPDATE_ERROR;
 extern IFM3D_CAMERA_EXPORT const int IFM3D_PCICCLIENT_UNSUPPORTED_DEVICE;
 extern IFM3D_CAMERA_EXPORT const int IFM3D_HEADER_VERSION_MISMATCH;
-extern IFM3D_CAMERA_EXPORT const int IFM3D_INTRINSIC_CALIBRATION_UNSUPPORTED_DEVICE;
-extern IFM3D_CAMERA_EXPORT const int IFM3D_INTRINSIC_CALIBRATION_UNSUPPORTED_FIRMWARE;
-extern IFM3D_CAMERA_EXPORT const int IFM3D_INVERSE_INTRINSIC_CALIBRATION_UNSUPPORTED_DEVICE;
-extern IFM3D_CAMERA_EXPORT const int IFM3D_INVERSE_INTRINSIC_CALIBRATION_UNSUPPORTED_FIRMWARE;
+extern IFM3D_CAMERA_EXPORT const int
+  IFM3D_INTRINSIC_CALIBRATION_UNSUPPORTED_DEVICE;
+extern IFM3D_CAMERA_EXPORT const int
+  IFM3D_INTRINSIC_CALIBRATION_UNSUPPORTED_FIRMWARE;
+extern IFM3D_CAMERA_EXPORT const int
+  IFM3D_INVERSE_INTRINSIC_CALIBRATION_UNSUPPORTED_DEVICE;
+extern IFM3D_CAMERA_EXPORT const int
+  IFM3D_INVERSE_INTRINSIC_CALIBRATION_UNSUPPORTED_FIRMWARE;
 extern IFM3D_CAMERA_EXPORT const int IFM3D_CURL_ERROR;
 extern IFM3D_CAMERA_EXPORT const int IFM3D_CURL_TIMEOUT;
 extern IFM3D_CAMERA_EXPORT const int IFM3D_CURL_ABORTED;
@@ -87,7 +90,7 @@ namespace ifm3d
    * @param[in] errnum The error number to translate to a string
    * @return A stringified version of the error
    */
-  const char *strerror(int errnum);
+  const char* strerror(int errnum);
 
   /**
    * Exception wrapper for library and system errors encountered by the
@@ -105,7 +108,7 @@ namespace ifm3d
     /**
      * Exception message
      */
-    virtual const char *what() const noexcept;
+    virtual const char* what() const noexcept;
 
     /**
      * Accessor to the underlying error code

--- a/modules/camera/include/ifm3d/camera/util.h
+++ b/modules/camera/include/ifm3d/camera/util.h
@@ -26,20 +26,20 @@ namespace ifm3d
   /**
    * Trim whitespace from left side of string
    */
-  std::string&
-  ltrim(std::string& str, const std::string& chars = "\t\n\v\f\r ");
+  std::string& ltrim(std::string& str,
+                     const std::string& chars = "\t\n\v\f\r ");
 
   /**
    * Trim whitespace from right side of string
    */
-  std::string&
-  rtrim(std::string& str, const std::string& chars = "\t\n\v\f\r ");
+  std::string& rtrim(std::string& str,
+                     const std::string& chars = "\t\n\v\f\r ");
 
   /**
    * Trim whitespace from left and right side of string
    */
-  std::string&
-  trim(std::string& str, const std::string& chars = "\t\n\v\f\r ");
+  std::string& trim(std::string& str,
+                    const std::string& chars = "\t\n\v\f\r ");
 
   /**
    * Split a string into its component parts based on a delimeter

--- a/modules/camera/src/libifm3d_camera/camera.cpp
+++ b/modules/camera/src/libifm3d_camera/camera.cpp
@@ -112,8 +112,9 @@ const unsigned int ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_PATCH = 4123;
 // A lookup table listing the read-only camera
 // parameters
 //================================================
+// clang-format off
 std::unordered_map<std::string,
-                   std::unordered_map<std::string, bool> >
+                   std::unordered_map<std::string, bool>>
 RO_LUT=
   {
     {"Device",
@@ -182,6 +183,7 @@ RO_LUT=
      }
     }
   };
+// clang-format on
 
 //================================================
 // Factory function for making cameras

--- a/modules/camera/src/libifm3d_camera/camera.cpp
+++ b/modules/camera/src/libifm3d_camera/camera.cpp
@@ -703,6 +703,7 @@ ifm3d::Camera::ToJSON_(const bool open_session)
         exec_toJSON();
     }
 
+  // clang-format off
   json j =
     {
       {
@@ -723,6 +724,7 @@ ifm3d::Camera::ToJSON_(const bool open_session)
        }
       }
     };
+  // clang-format on
 
   return j;
 }

--- a/modules/camera/src/libifm3d_camera/camera.cpp
+++ b/modules/camera/src/libifm3d_camera/camera.cpp
@@ -37,15 +37,14 @@
 const std::string ifm3d::DEFAULT_PASSWORD = "";
 const std::uint16_t ifm3d::DEFAULT_XMLRPC_PORT = 80;
 const int ifm3d::DEFAULT_PCIC_PORT = 50010;
-const std::string ifm3d::DEFAULT_IP =
-  std::getenv("IFM3D_IP") == nullptr ?
-  "192.168.0.69" : std::string(std::getenv("IFM3D_IP"));
+const std::string ifm3d::DEFAULT_IP = std::getenv("IFM3D_IP") == nullptr ?
+                                        "192.168.0.69" :
+                                        std::string(std::getenv("IFM3D_IP"));
 const int ifm3d::MAX_HEARTBEAT = 300; // secs
 const std::size_t ifm3d::SESSION_ID_SZ = 32;
 const std::string ifm3d::DEFAULT_APPLICATION_TYPE = "Camera";
 
-auto __ifm3d_session_id__ = []() -> std::string
-{
+auto __ifm3d_session_id__ = []() -> std::string {
   std::string sid;
 
   try
@@ -57,9 +56,9 @@ auto __ifm3d_session_id__ = []() -> std::string
       else
         {
           sid = std::string(std::getenv("IFM3D_SESSION_ID"));
-          if (! ((sid.size() == ifm3d::SESSION_ID_SZ) &&
-                 (sid.find_first_not_of("0123456789abcdefABCDEF") ==
-                  std::string::npos)))
+          if (!((sid.size() == ifm3d::SESSION_ID_SZ) &&
+                (sid.find_first_not_of("0123456789abcdefABCDEF") ==
+                 std::string::npos)))
             {
               LOG(WARNING) << "Invalid session id: " << sid;
               sid = "";
@@ -72,8 +71,7 @@ auto __ifm3d_session_id__ = []() -> std::string
     }
   catch (const std::exception& ex)
     {
-      LOG(WARNING) << "When trying to set default session id: "
-                   << ex.what();
+      LOG(WARNING) << "When trying to set default session id: " << ex.what();
 
       sid = "";
     }
@@ -90,7 +88,8 @@ const int ifm3d::DEV_O3X_MAX = 767;
 
 const std::string ifm3d::ASSUME_DEVICE =
   std::getenv("IFM3D_DEVICE") == nullptr ?
-  "" : std::string(std::getenv("IFM3D_DEVICE"));
+    "" :
+    std::string(std::getenv("IFM3D_DEVICE"));
 
 const unsigned int ifm3d::O3D_TIME_SUPPORT_MAJOR = 1;
 const unsigned int ifm3d::O3D_TIME_SUPPORT_MINOR = 20;
@@ -219,13 +218,11 @@ ifm3d::Camera::MakeShared(const std::string& ip,
     {
       if (ex.code() == IFM3D_XMLRPC_TIMEOUT)
         {
-          LOG(WARNING) << "Could not probe device type: "
-                       << ex.what();
+          LOG(WARNING) << "Could not probe device type: " << ex.what();
         }
       else
         {
-          LOG(ERROR) << "While trying to instantiate camera: "
-                     << ex.what();
+          LOG(ERROR) << "While trying to instantiate camera: " << ex.what();
           //
           // XXX: For now, we re-throw. I am not sure what else would
           // go wrong here except for a network time out. To that end,
@@ -312,10 +309,10 @@ ifm3d::Camera::SetTemporaryApplicationParameters(
   // NOTE: we "fail" silently here. Assumption is a closed loop check by the
   // user to see if/when the temp params take effect.
   //
-  if (this->IsO3D() &&
-      (! this->CheckMinimumFirmwareVersion(ifm3d::O3D_TMP_PARAMS_SUPPORT_MAJOR,
-                                     ifm3d::O3D_TMP_PARAMS_SUPPORT_MINOR,
-                                     ifm3d::O3D_TMP_PARAMS_SUPPORT_PATCH)))
+  if (this->IsO3D() && (!this->CheckMinimumFirmwareVersion(
+                         ifm3d::O3D_TMP_PARAMS_SUPPORT_MAJOR,
+                         ifm3d::O3D_TMP_PARAMS_SUPPORT_MINOR,
+                         ifm3d::O3D_TMP_PARAMS_SUPPORT_PATCH)))
     {
       LOG(WARNING) << "Setting temp params not supported by this device!";
       return;
@@ -327,7 +324,7 @@ ifm3d::Camera::SetTemporaryApplicationParameters(
 void
 ifm3d::Camera::ForceTrigger()
 {
-  if (! this->IsO3X())
+  if (!this->IsO3X())
     {
       return;
     }
@@ -397,7 +394,7 @@ ifm3d::Camera::IsO3X()
     {
       try
         {
-          devid = std::atoi(dt.substr(n+1).c_str());
+          devid = std::atoi(dt.substr(n + 1).c_str());
         }
       catch (std::out_of_range& ex)
         {
@@ -405,8 +402,7 @@ ifm3d::Camera::IsO3X()
         }
     }
 
-  if ((devid >= ifm3d::DEV_O3X_MIN) &&
-      (devid <= ifm3d::DEV_O3X_MAX))
+  if ((devid >= ifm3d::DEV_O3X_MIN) && (devid <= ifm3d::DEV_O3X_MAX))
     {
       return true;
     }
@@ -424,7 +420,7 @@ ifm3d::Camera::IsO3D()
     {
       try
         {
-          devid = std::atoi(dt.substr(n+1).c_str());
+          devid = std::atoi(dt.substr(n + 1).c_str());
         }
       catch (std::out_of_range& ex)
         {
@@ -432,8 +428,7 @@ ifm3d::Camera::IsO3D()
         }
     }
 
-  if ((devid >= ifm3d::DEV_O3D_MIN) &&
-      (devid <= ifm3d::DEV_O3D_MAX))
+  if ((devid >= ifm3d::DEV_O3D_MIN) && (devid <= ifm3d::DEV_O3D_MAX))
     {
       return true;
     }
@@ -462,14 +457,11 @@ ifm3d::Camera::ApplicationList()
 
   for (auto& app : apps)
     {
-      json dict =
-        {
-          {"Index", app.index},
-          {"Id", app.id},
-          {"Name", app.name},
-          {"Description", app.description},
-          {"Active", app.index == active ? true : false}
-        };
+      json dict = {{"Index", app.index},
+                   {"Id", app.id},
+                   {"Name", app.name},
+                   {"Description", app.description},
+                   {"Active", app.index == active ? true : false}};
 
       retval.push_back(dict);
     }
@@ -480,18 +472,18 @@ ifm3d::Camera::ApplicationList()
 std::vector<std::string>
 ifm3d::Camera::ApplicationTypes()
 {
-  return this->pImpl->WrapInEditSession<std::vector<std::string> >(
-    [this]()->std::vector<std::string>
-    { return this->pImpl->ApplicationTypes(); });
+  return this->pImpl->WrapInEditSession<std::vector<std::string>>(
+    [this]() -> std::vector<std::string> {
+      return this->pImpl->ApplicationTypes();
+    });
 }
 
 std::vector<std::string>
 ifm3d::Camera::ImagerTypes()
 {
-  return this->pImpl->WrapInEditSession<std::vector<std::string> >(
-    [this]()->std::vector<std::string>
-    {
-      if (! this->IsO3X())
+  return this->pImpl->WrapInEditSession<std::vector<std::string>>(
+    [this]() -> std::vector<std::string> {
+      if (!this->IsO3X())
         {
           this->pImpl->EditApplication(this->ActiveApplication());
         }
@@ -509,7 +501,7 @@ ifm3d::Camera::CreateApplication(const std::string& type)
     }
 
   return this->pImpl->WrapInEditSession<int>(
-    [this,&type]()->int { return this->pImpl->CreateApplication(type); });
+    [this, &type]() -> int { return this->pImpl->CreateApplication(type); });
 }
 
 int
@@ -522,7 +514,7 @@ ifm3d::Camera::CopyApplication(int idx)
     }
 
   return this->pImpl->WrapInEditSession<int>(
-    [this,idx]()->int { return this->pImpl->CopyApplication(idx); });
+    [this, idx]() -> int { return this->pImpl->CopyApplication(idx); });
 }
 
 void
@@ -535,7 +527,7 @@ ifm3d::Camera::DeleteApplication(int idx)
     }
 
   this->pImpl->WrapInEditSession(
-     [this,idx]() { this->pImpl->DeleteApplication(idx); });
+    [this, idx]() { this->pImpl->DeleteApplication(idx); });
 }
 
 void
@@ -548,23 +540,25 @@ void
 ifm3d::Camera::SetCurrentTime(int epoch_secs)
 {
   this->pImpl->WrapInEditSession(
-    [this,epoch_secs]() { this->pImpl->SetCurrentTime(epoch_secs); });
+    [this, epoch_secs]() { this->pImpl->SetCurrentTime(epoch_secs); });
 }
 
 std::vector<std::uint8_t>
 ifm3d::Camera::ExportIFMConfig()
 {
-  return this->pImpl->WrapInEditSession<std::vector<std::uint8_t> >(
-    [this]()->std::vector<std::uint8_t>
-    { return this->pImpl->ExportIFMConfig(); });
+  return this->pImpl->WrapInEditSession<std::vector<std::uint8_t>>(
+    [this]() -> std::vector<std::uint8_t> {
+      return this->pImpl->ExportIFMConfig();
+    });
 }
 
 std::vector<std::uint8_t>
 ifm3d::Camera::ExportIFMApp(int idx)
 {
-  return this->pImpl->WrapInEditSession<std::vector<std::uint8_t> >(
-    [this,idx]()->std::vector<std::uint8_t>
-    { return this->pImpl->ExportIFMApp(idx); });
+  return this->pImpl->WrapInEditSession<std::vector<std::uint8_t>>(
+    [this, idx]() -> std::vector<std::uint8_t> {
+      return this->pImpl->ExportIFMApp(idx);
+    });
 }
 
 void
@@ -572,19 +566,20 @@ ifm3d::Camera::ImportIFMConfig(const std::vector<std::uint8_t>& bytes,
                                std::uint16_t flags)
 {
   return this->pImpl->WrapInEditSession(
-    [this,&bytes,flags]() { this->pImpl->ImportIFMConfig(bytes, flags); });
+    [this, &bytes, flags]() { this->pImpl->ImportIFMConfig(bytes, flags); });
 }
 
 int
 ifm3d::Camera::ImportIFMApp(const std::vector<std::uint8_t>& bytes)
 {
   return this->pImpl->WrapInEditSession<int>(
-    [this,&bytes]()->int { return this->pImpl->ImportIFMApp(bytes); });
+    [this, &bytes]() -> int { return this->pImpl->ImportIFMApp(bytes); });
 }
 
 bool
 ifm3d::Camera::CheckMinimumFirmwareVersion(unsigned int major,
-                                     unsigned int minor, unsigned int patch)
+                                           unsigned int minor,
+                                           unsigned int patch)
 {
 
   auto data = this->pImpl->SWVersion();
@@ -596,27 +591,27 @@ ifm3d::Camera::CheckMinimumFirmwareVersion(unsigned int major,
     {
       strings.push_back(token);
     }
-  const auto cmajor = std::stoi(strings[0],nullptr);
-  const auto cminor = std::stoi(strings[1],nullptr);
-  const auto cpatch = std::stoi(strings[2],nullptr);
+  const auto cmajor = std::stoi(strings[0], nullptr);
+  const auto cminor = std::stoi(strings[1], nullptr);
+  const auto cpatch = std::stoi(strings[2], nullptr);
   auto res = false;
-  if(cmajor > major)
+  if (cmajor > major)
     {
       res = true;
     }
   else if (cmajor == major)
     {
-      if(cminor > minor)
+      if (cminor > minor)
         {
           res = true;
         }
       else if (cminor == minor)
         {
-          if(cpatch > patch)
+          if (cpatch > patch)
             {
               res = true;
             }
-          else if(cpatch == patch)
+          else if (cpatch == patch)
             {
               res = true;
             }
@@ -640,67 +635,68 @@ ifm3d::Camera::ToJSON_(const bool open_session)
   json net_info, app_info;
   json time_info = json::parse("{}");
 
-  auto exec_toJSON = [this,&net_info,&time_info,&app_info,&app_list]()
+  auto exec_toJSON = [this, &net_info, &time_info, &app_info, &app_list]() {
+    net_info = json(this->pImpl->NetInfo());
+    if (this->IsO3X() || (this->IsO3D() && this->CheckMinimumFirmwareVersion(
+                                             ifm3d::O3D_TIME_SUPPORT_MAJOR,
+                                             ifm3d::O3D_TIME_SUPPORT_MINOR,
+                                             ifm3d::O3D_TIME_SUPPORT_PATCH)))
+      {
+        time_info = json(this->pImpl->TimeInfo());
+      }
+    app_info = json::parse("[]");
+
+    for (auto& app : app_list)
+      {
+        int idx = app["Index"].get<int>();
+        if (!this->IsO3X())
+          {
+            this->pImpl->EditApplication(idx);
+          }
+
+        json app_json = json(this->pImpl->AppInfo());
+        app_json["Index"] = std::to_string(idx);
+        app_json["Id"] = std::to_string(app["Id"].get<int>());
+
+        json imager_json = json(this->pImpl->ImagerInfo());
+
+        /* Initialize the imager_json filters with defult values for
+           compatibility with o3x which does not support dedicated xmlrpc
+           filter objects since there are no config options for the o3x filter
+         */
+        std::unordered_map<std::string, std::string> spatialFil = {
+          {"MaskSize", "0"}};
+        std::unordered_map<std::string, std::string> tmpFil = {
+          {}}; // empty map
+        imager_json["SpatialFilter"] = json(spatialFil);
+        imager_json["TemporalFilter"] = json(tmpFil);
+
+        if (!this->IsO3X())
+          {
+            json sfilt_json = json(this->pImpl->SpatialFilterInfo());
+            imager_json["SpatialFilter"] = sfilt_json;
+
+            json tfilt_json = json(this->pImpl->TemporalFilterInfo());
+            imager_json["TemporalFilter"] = tfilt_json;
+          }
+
+        app_json["Imager"] = imager_json;
+
+        app_info.push_back(app_json);
+
+        if (!this->IsO3X())
+          {
+            this->pImpl->StopEditingApplication();
+          }
+      }
+  };
+  if (open_session)
     {
-      net_info = json(this->pImpl->NetInfo());
-      if (this->IsO3X() ||
-          (this->IsO3D() &&
-           this->CheckMinimumFirmwareVersion(ifm3d::O3D_TIME_SUPPORT_MAJOR,
-                                       ifm3d::O3D_TIME_SUPPORT_MINOR,
-                                       ifm3d::O3D_TIME_SUPPORT_PATCH)))
-        {
-          time_info = json(this->pImpl->TimeInfo());
-        }
-      app_info = json::parse("[]");
-
-      for (auto& app : app_list)
-        {
-          int idx = app["Index"].get<int>();
-          if (! this->IsO3X())
-            {
-              this->pImpl->EditApplication(idx);
-            }
-
-          json app_json = json(this->pImpl->AppInfo());
-          app_json["Index"] = std::to_string(idx);
-          app_json["Id"] = std::to_string(app["Id"].get<int>());
-
-          json imager_json = json(this->pImpl->ImagerInfo());
-
-	  /* Initialize the imager_json filters with defult values for
-	     compatibility with o3x which does not support dedicated xmlrpc
-             filter objects since there are no config options for the o3x filter */
-	  std::unordered_map<std::string, std::string> spatialFil = {{"MaskSize", "0"}};
-          std::unordered_map<std::string, std::string> tmpFil = {{}}; // empty map
-          imager_json["SpatialFilter"] = json(spatialFil);
-          imager_json["TemporalFilter"] = json(tmpFil);
-
-          if (! this->IsO3X())
-            {
-		json sfilt_json = json(this->pImpl->SpatialFilterInfo());
-                imager_json["SpatialFilter"] = sfilt_json;
-
-                json tfilt_json = json(this->pImpl->TemporalFilterInfo());
-                imager_json["TemporalFilter"] = tfilt_json;
-            }
-
-          app_json["Imager"] = imager_json;
-
-          app_info.push_back(app_json);
-
-          if (! this->IsO3X())
-            {
-              this->pImpl->StopEditingApplication();
-            }
-        }
-    };
-  if(open_session)
-    {
-        this->pImpl->WrapInEditSession(exec_toJSON);
+      this->pImpl->WrapInEditSession(exec_toJSON);
     }
   else
     {
-        exec_toJSON();
+      exec_toJSON();
     }
 
   // clang-format off
@@ -732,7 +728,7 @@ ifm3d::Camera::ToJSON_(const bool open_session)
 json
 ifm3d::Camera::ToJSON()
 {
-      return ToJSON_();
+  return ToJSON_();
 }
 
 std::string
@@ -742,16 +738,16 @@ ifm3d::Camera::ToJSONStr()
 }
 
 void
-ifm3d::Camera::FromJSON_(const json& j_curr,
-                         const json& j_new,
-                         std::function<void(const std::string&,
-                                            const std::string&)> SetFunc,
-                         std::function<void()> SaveFunc,
-                         const std::string& name,
-                         int idx)
+ifm3d::Camera::FromJSON_(
+  const json& j_curr,
+  const json& j_new,
+  std::function<void(const std::string&, const std::string&)> SetFunc,
+  std::function<void()> SaveFunc,
+  const std::string& name,
+  int idx)
 {
   VLOG(IFM3D_TRACE) << "Setting " << name << " parameters";
-  if (! j_new.is_object())
+  if (!j_new.is_object())
     {
       LOG(ERROR) << "The passed in " << name << " json should be an object!";
       VLOG(IFM3D_TRACE) << "Invalid JSON was: " << j_new.dump();
@@ -761,7 +757,7 @@ ifm3d::Camera::FromJSON_(const json& j_curr,
 
   if (idx > 0)
     {
-      if (! this->IsO3X())
+      if (!this->IsO3X())
         {
           VLOG(IFM3D_TRACE) << "Editing app at idx=" << idx;
           this->pImpl->EditApplication(idx);
@@ -772,13 +768,12 @@ ifm3d::Camera::FromJSON_(const json& j_curr,
   for (auto it = j_new.begin(); it != j_new.end(); ++it)
     {
       std::string key = it.key();
-      VLOG(IFM3D_TRACE) << "Processing key="
-                        << key << ", with val="
-                        << j_new[key].dump(2);
+      VLOG(IFM3D_TRACE) << "Processing key=" << key
+                        << ", with val=" << j_new[key].dump(2);
       if (it.value().is_null())
         {
-          LOG(WARNING)
-            << "Skipping " <<  key << ", null value -- should be string!";
+          LOG(WARNING) << "Skipping " << key
+                       << ", null value -- should be string!";
           continue;
         }
       std::string val = j_new[key].get<std::string>();
@@ -791,8 +786,7 @@ ifm3d::Camera::FromJSON_(const json& j_curr,
                   if (RO_LUT.at(name).at(key))
                     {
                       VLOG(IFM3D_TRACE)
-                        << "Skipping read-only " << name
-                        << " param: " << key;
+                        << "Skipping read-only " << name << " param: " << key;
                       continue;
                     }
                 }
@@ -802,8 +796,8 @@ ifm3d::Camera::FromJSON_(const json& j_curr,
                   // r/w parameter
                 }
 
-              VLOG(IFM3D_TRACE) << "Setting " << name << " parameter: "
-                                << key << "=" << val;
+              VLOG(IFM3D_TRACE)
+                << "Setting " << name << " parameter: " << key << "=" << val;
               SetFunc(key, val);
               do_save = true;
             }
@@ -812,8 +806,7 @@ ifm3d::Camera::FromJSON_(const json& j_curr,
               if (ex.code() == IFM3D_READONLY_PARAM)
                 {
                   LOG(WARNING)
-                    << "Tried to set read-only " << name << " param: "
-                    << key;
+                    << "Tried to set read-only " << name << " param: " << key;
                 }
               else
                 {
@@ -823,8 +816,7 @@ ifm3d::Camera::FromJSON_(const json& j_curr,
         }
       else
         {
-          VLOG(IFM3D_TRACE)
-            << "Skipping " << key << ", no change in value";
+          VLOG(IFM3D_TRACE) << "Skipping " << key << ", no change in value";
         }
     }
 
@@ -832,13 +824,13 @@ ifm3d::Camera::FromJSON_(const json& j_curr,
     {
       SaveFunc();
     }
-  if(idx > 0)
+  if (idx > 0)
     {
-    if(!this->IsO3X())
-      {
-        VLOG(IFM3D_TRACE) << "Stop editing app at idx=" << idx;
-        this->pImpl->StopEditingApplication();
-      }
+      if (!this->IsO3X())
+        {
+          VLOG(IFM3D_TRACE) << "Stop editing app at idx=" << idx;
+          this->pImpl->StopEditingApplication();
+        }
     }
 }
 
@@ -846,7 +838,7 @@ void
 ifm3d::Camera::FromJSON(const json& j)
 {
   VLOG(IFM3D_TRACE) << "Checking if passed in JSON is an object";
-  if (! j.is_object())
+  if (!j.is_object())
     {
       LOG(ERROR) << "The passed in json should be an object!";
       VLOG(IFM3D_TRACE) << "Invalid JSON was: " << j.dump();
@@ -863,228 +855,233 @@ ifm3d::Camera::FromJSON(const json& j)
   json root = j.count("ifm3d") ? j["ifm3d"] : j;
 
   // Ensure we cancel the session when leaving this method
-  this->pImpl->WrapInEditSession([this,&root,&j,&current]()
-    {
-      // Device
-      json j_dev = root["Device"];
-      if (! j_dev.is_null())
+  this->pImpl->WrapInEditSession([this, &root, &j, &current]() {
+    // Device
+    json j_dev = root["Device"];
+    if (!j_dev.is_null())
       {
-        this->FromJSON_(current["ifm3d"]["Device"], j_dev,
-            [this](const std::string& k, const std::string& v)
-            {
-              this->pImpl->SetDeviceParameter(k,v);
-            },
-          [this](){ this->pImpl->SaveDevice(); },
+        this->FromJSON_(
+          current["ifm3d"]["Device"],
+          j_dev,
+          [this](const std::string& k, const std::string& v) {
+            this->pImpl->SetDeviceParameter(k, v);
+          },
+          [this]() { this->pImpl->SaveDevice(); },
           "Device");
       }
 
-      // Apps - requires careful/special treatment
-      json j_apps = root["Apps"];
-      if (! j_apps.is_null())
-        {
-          if (! j_apps.is_array())
-            {
-              LOG(ERROR) << "The `Apps` element should be an array!";
-              VLOG(IFM3D_TRACE) << "Invalid JSON was: " << j_apps.dump();
+    // Apps - requires careful/special treatment
+    json j_apps = root["Apps"];
+    if (!j_apps.is_null())
+      {
+        if (!j_apps.is_array())
+          {
+            LOG(ERROR) << "The `Apps` element should be an array!";
+            VLOG(IFM3D_TRACE) << "Invalid JSON was: " << j_apps.dump();
 
-              throw ifm3d::error_t(IFM3D_JSON_ERROR);
-            }
+            throw ifm3d::error_t(IFM3D_JSON_ERROR);
+          }
 
-          VLOG(IFM3D_TRACE) << "Looping over applications";
-          for (auto& j_app : j_apps)
-            {
-              if (! j_app.is_object())
+        VLOG(IFM3D_TRACE) << "Looping over applications";
+        for (auto& j_app : j_apps)
+          {
+            if (!j_app.is_object())
               {
-                LOG(ERROR)
-                  << "All 'Apps' must be a JSON object!";
-                VLOG(IFM3D_TRACE)
-                  << "Invalid JSON was: " << j_app.dump();
+                LOG(ERROR) << "All 'Apps' must be a JSON object!";
+                VLOG(IFM3D_TRACE) << "Invalid JSON was: " << j_app.dump();
                 throw ifm3d::error_t(IFM3D_JSON_ERROR);
               }
 
-              // First we determine if we are editing an existing application or if
-              // we are creating a new one. If no index is specified, we create a
-              // new application.
-              int idx = -1;
-              if (j_app["Index"].is_null())
-                {
-                  if (! this->IsO3X())
-                    {
-                      VLOG(IFM3D_TRACE) << "Creating new application";
-                      idx = j_app["Type"].is_null() ?
-                      this->pImpl->CreateApplication(
-                          DEFAULT_APPLICATION_TYPE) :
-                          this->pImpl->CreateApplication(
-                            j_app["Type"].get<std::string>());
-
-                      VLOG(IFM3D_TRACE)
-                        << "Created new app, updating our dump";
-                      current = this->ToJSON_(false);
-                    }
-                    else
-                    {
-                      VLOG(IFM3D_TRACE)
-                        << "O3X only has a single app, assuming idx=1";
-                      idx = 1;
-                    }
-              }
-              else
+            // First we determine if we are editing an existing application or
+            // if we are creating a new one. If no index is specified, we
+            // create a new application.
+            int idx = -1;
+            if (j_app["Index"].is_null())
               {
-                VLOG(IFM3D_TRACE)
-                  << "Getting index of existing application";
+                if (!this->IsO3X())
+                  {
+                    VLOG(IFM3D_TRACE) << "Creating new application";
+                    idx = j_app["Type"].is_null() ?
+                            this->pImpl->CreateApplication(
+                              DEFAULT_APPLICATION_TYPE) :
+                            this->pImpl->CreateApplication(
+                              j_app["Type"].get<std::string>());
+
+                    VLOG(IFM3D_TRACE) << "Created new app, updating our dump";
+                    current = this->ToJSON_(false);
+                  }
+                else
+                  {
+                    VLOG(IFM3D_TRACE)
+                      << "O3X only has a single app, assuming idx=1";
+                    idx = 1;
+                  }
+              }
+            else
+              {
+                VLOG(IFM3D_TRACE) << "Getting index of existing application";
                 idx = std::stoi(j_app["Index"].get<std::string>());
               }
 
-              VLOG(IFM3D_TRACE) << "Application of interest is at index="
-                << idx;
+            VLOG(IFM3D_TRACE) << "Application of interest is at index=" << idx;
 
-              // now in `current` (which is a whole camera dump)
-              // we need to find the application at index `idx`.
-              json curr_app = json({});
-              json curr_apps = current["ifm3d"]["Apps"];
-              bool app_found = false;
-              for (auto& a : curr_apps)
-                {
-                  if (std::stoi(a["Index"].get<std::string>()) == idx)
-                    {
-                      curr_app = a;
-                      app_found = true;
-                      break;
-                    }
-                }
+            // now in `current` (which is a whole camera dump)
+            // we need to find the application at index `idx`.
+            json curr_app = json({});
+            json curr_apps = current["ifm3d"]["Apps"];
+            bool app_found = false;
+            for (auto& a : curr_apps)
+              {
+                if (std::stoi(a["Index"].get<std::string>()) == idx)
+                  {
+                    curr_app = a;
+                    app_found = true;
+                    break;
+                  }
+              }
 
-              if (! app_found)
-                {
-                  LOG(ERROR) << "Could not find an application at index="
-                  << idx;
-                  throw ifm3d::error_t(IFM3D_JSON_ERROR);
-                }
+            if (!app_found)
+              {
+                LOG(ERROR) << "Could not find an application at index=" << idx;
+                throw ifm3d::error_t(IFM3D_JSON_ERROR);
+              }
 
-              // at this point both the new and current
-              // should have the same index and type and
-              // we want to make sure of that.
-              j_app["Index"] = curr_app["Index"];
-              j_app["Type"] = curr_app["Type"];
+            // at this point both the new and current
+            // should have the same index and type and
+            // we want to make sure of that.
+            j_app["Index"] = curr_app["Index"];
+            j_app["Type"] = curr_app["Type"];
 
-              // pull out the imager sub-tree (we treat that separately)
-              json j_im = j_app["Imager"];
-              if (! j_im.is_null())
+            // pull out the imager sub-tree (we treat that separately)
+            json j_im = j_app["Imager"];
+            if (!j_im.is_null())
               {
                 j_app.erase("Imager");
               }
 
-              this->FromJSON_(curr_app, j_app,
-                [this](const std::string& k, const std::string& v)
-                  {
-                    this->pImpl->SetAppParameter(k,v);
-                  },
-                [this](){ this->pImpl->SaveApp(); },
-                "App", idx);
+            this->FromJSON_(
+              curr_app,
+              j_app,
+              [this](const std::string& k, const std::string& v) {
+                this->pImpl->SetAppParameter(k, v);
+              },
+              [this]() { this->pImpl->SaveApp(); },
+              "App",
+              idx);
 
-              json s_filt = j_im["SpatialFilter"];
-              if (! s_filt.is_null())
-                {
-                  j_im.erase("SpatialFilter");
-                }
-
-              json t_filt = j_im["TemporalFilter"];
-              if (! t_filt.is_null())
-                {
-                  j_im.erase("TemporalFilter");
-                }
-
-              this->FromJSON_(curr_app["Imager"], j_im,
-                [this](const std::string& k, const std::string& v)
-                  {
-                    if (k == "Type")
-                      {
-                        this->pImpl->ChangeImagerType(v);
-                      }
-                    else
-                      {
-                        this->pImpl->SetImagerParameter(k,v);
-                      }
-                  },
-                [this](){ this->pImpl->SaveApp(); },
-                "Imager", idx);
-
-              if (! this->IsO3X())
-                {
-
-                  if (! s_filt.is_null())
-                    {
-                      this->FromJSON_(curr_app["Imager"]["SpatialFilter"],
-                          s_filt,
-                          [this](const std::string& k, const std::string& v)
-                            { this->pImpl->SetSpatialFilterParameter(k,v); },
-                          [this](){ this->pImpl->SaveApp(); },
-                          "SpatialFilter", idx);
-                    }
-
-                  if (! t_filt.is_null())
-                    {
-                      this->FromJSON_(curr_app["Imager"]["TemporalFilter"],
-                          t_filt,
-                          [this](const std::string& k, const std::string& v)
-                            {
-                              this->pImpl->SetTemporalFilterParameter(k,v);
-                            },
-                          [this](){ this->pImpl->SaveApp(); },
-                          "TemporalFilter", idx);
-                    }
-                }
-            }
-        }
-
-        // Time
-        if (this->IsO3X() ||
-            (this->IsO3D() &&
-             this->CheckMinimumFirmwareVersion(ifm3d::O3D_TIME_SUPPORT_MAJOR,
-               ifm3d::O3D_TIME_SUPPORT_MINOR,
-              ifm3d::O3D_TIME_SUPPORT_PATCH)))
-          {
-            json j_time = root["Time"];
-            if (! j_time.is_null())
+            json s_filt = j_im["SpatialFilter"];
+            if (!s_filt.is_null())
               {
-                this->FromJSON_(current["ifm3d"]["Time"], j_time,
-                  [this](const std::string& k, const std::string& v)
-                    { this->pImpl->SetTimeParameter(k,v); },
-                  [this](){ this->pImpl->SaveTime(); },
-                  "Time");
+                j_im.erase("SpatialFilter");
+              }
+
+            json t_filt = j_im["TemporalFilter"];
+            if (!t_filt.is_null())
+              {
+                j_im.erase("TemporalFilter");
+              }
+
+            this->FromJSON_(
+              curr_app["Imager"],
+              j_im,
+              [this](const std::string& k, const std::string& v) {
+                if (k == "Type")
+                  {
+                    this->pImpl->ChangeImagerType(v);
+                  }
+                else
+                  {
+                    this->pImpl->SetImagerParameter(k, v);
+                  }
+              },
+              [this]() { this->pImpl->SaveApp(); },
+              "Imager",
+              idx);
+
+            if (!this->IsO3X())
+              {
+
+                if (!s_filt.is_null())
+                  {
+                    this->FromJSON_(
+                      curr_app["Imager"]["SpatialFilter"],
+                      s_filt,
+                      [this](const std::string& k, const std::string& v) {
+                        this->pImpl->SetSpatialFilterParameter(k, v);
+                      },
+                      [this]() { this->pImpl->SaveApp(); },
+                      "SpatialFilter",
+                      idx);
+                  }
+
+                if (!t_filt.is_null())
+                  {
+                    this->FromJSON_(
+                      curr_app["Imager"]["TemporalFilter"],
+                      t_filt,
+                      [this](const std::string& k, const std::string& v) {
+                        this->pImpl->SetTemporalFilterParameter(k, v);
+                      },
+                      [this]() { this->pImpl->SaveApp(); },
+                      "TemporalFilter",
+                      idx);
+                  }
               }
           }
+      }
 
-        // Network - we do this last intentionally!
-        json j_net = root["Net"];
-        if (! j_net.is_null())
+    // Time
+    if (this->IsO3X() || (this->IsO3D() && this->CheckMinimumFirmwareVersion(
+                                             ifm3d::O3D_TIME_SUPPORT_MAJOR,
+                                             ifm3d::O3D_TIME_SUPPORT_MINOR,
+                                             ifm3d::O3D_TIME_SUPPORT_PATCH)))
+      {
+        json j_time = root["Time"];
+        if (!j_time.is_null())
           {
-            this->FromJSON_(current["ifm3d"]["Net"], j_net,
-              [this](const std::string& k, const std::string& v)
-                { this->pImpl->SetNetParameter(k,v); },
-              [this]()
-                { // we are changing network parameters,
-                  // we expect a timeout!
-                try
-                  {
-                    this->pImpl->SaveNet();
-                   }
-                catch (const ifm3d::error_t& ex)
-                  {
-                    if (ex.code() == IFM3D_XMLRPC_TIMEOUT)
-                    {
-                      LOG(WARNING)
-                        << "XML-RPC timeout saving net params, "
-                        << "this is expected";
-                    }
-                    else
-                    {
-                      throw;
-                    }
-                  }
-                },
-              "Net");
+            this->FromJSON_(
+              current["ifm3d"]["Time"],
+              j_time,
+              [this](const std::string& k, const std::string& v) {
+                this->pImpl->SetTimeParameter(k, v);
+              },
+              [this]() { this->pImpl->SaveTime(); },
+              "Time");
           }
-      });
+      }
+
+    // Network - we do this last intentionally!
+    json j_net = root["Net"];
+    if (!j_net.is_null())
+      {
+        this->FromJSON_(
+          current["ifm3d"]["Net"],
+          j_net,
+          [this](const std::string& k, const std::string& v) {
+            this->pImpl->SetNetParameter(k, v);
+          },
+          [this]() { // we are changing network parameters,
+                     // we expect a timeout!
+            try
+              {
+                this->pImpl->SaveNet();
+              }
+            catch (const ifm3d::error_t& ex)
+              {
+                if (ex.code() == IFM3D_XMLRPC_TIMEOUT)
+                  {
+                    LOG(WARNING) << "XML-RPC timeout saving net params, "
+                                 << "this is expected";
+                  }
+                else
+                  {
+                    throw;
+                  }
+              }
+          },
+          "Net");
+      }
+  });
 }
 
 void
@@ -1109,11 +1106,11 @@ ifm3d::Camera::FromJSONStr(const std::string& jstr)
 void
 ifm3d::Camera::SetPassword(std::string password)
 {
-  this->pImpl->WrapInEditSession(
-	[this, password]() { password == "" ?
-	this->pImpl->DisablePassword() : this->pImpl->ActivatePassword(password);
-	this->pImpl->SaveDevice(); });
-
+  this->pImpl->WrapInEditSession([this, password]() {
+    password == "" ? this->pImpl->DisablePassword() :
+                     this->pImpl->ActivatePassword(password);
+    this->pImpl->SaveDevice();
+  });
 }
 
 //================================================

--- a/modules/camera/src/libifm3d_camera/camera_impl.hpp
+++ b/modules/camera/src/libifm3d_camera/camera_impl.hpp
@@ -48,7 +48,8 @@ namespace ifm3d
   const std::string XMLRPC_SPATIALFILTER = "spatialfilter";
   const std::string XMLRPC_TEMPORALFILTER = "temporalfilter";
 
-  using app_entry_t = struct {
+  using app_entry_t = struct
+  {
     int index;
     int id;
     std::string name;
@@ -61,7 +62,8 @@ namespace ifm3d
   class Camera::Impl
   {
   public:
-    Impl(const std::string& ip, const std::uint16_t xmlrpc_port,
+    Impl(const std::string& ip,
+         const std::uint16_t xmlrpc_port,
          const std::string& password);
     ~Impl();
 
@@ -95,8 +97,8 @@ namespace ifm3d
     bool CancelSession(const std::string& sid);
     int Heartbeat(int hb);
     void SetOperatingMode(const ifm3d::Camera::operating_mode& mode);
-    void SetTemporaryApplicationParameters(const std::unordered_map<std::string,
-                                           std::string>& params);
+    void SetTemporaryApplicationParameters(
+      const std::unordered_map<std::string, std::string>& params);
     std::vector<std::uint8_t> ExportIFMConfig();
     std::vector<std::uint8_t> ExportIFMApp(int idx);
     void ImportIFMConfig(const std::vector<std::uint8_t>& bytes,
@@ -161,7 +163,8 @@ namespace ifm3d
     // Session wrappers
     // ---------------------------------------------
     template <typename T>
-    T WrapInEditSession(std::function<T()> f)
+    T
+    WrapInEditSession(std::function<T()> f)
     {
       T retval;
       try
@@ -180,7 +183,8 @@ namespace ifm3d
       return retval;
     }
 
-    void WrapInEditSession(std::function<void()> f)
+    void
+    WrapInEditSession(std::function<void()> f)
     {
       try
         {
@@ -194,7 +198,7 @@ namespace ifm3d
           this->CancelSession();
           throw;
         }
-        this->CancelSession();
+      this->CancelSession();
     }
 
   private:
@@ -208,18 +212,20 @@ namespace ifm3d
     std::mutex session_mutex_;
 
     // utilities for taking xmlrpc structures to STL structures
-    std::unordered_map<std::string, std::string> const
-    value_struct_to_map(const xmlrpc_c::value_struct& vs);
+    std::unordered_map<std::string, std::string> const value_struct_to_map(
+      const xmlrpc_c::value_struct& vs);
 
     std::unordered_map<std::string,
-                       std::unordered_map<std::string, std::string> > const
+                       std::unordered_map<std::string, std::string>> const
     value_struct_to_map_of_maps(const xmlrpc_c::value_struct& vs);
 
     // ---------------------------------------------
     // Terminates recursion over the parameter pack
     // in _XSetParams
     // ---------------------------------------------
-    void _XSetParams(xmlrpc_c::paramList& params) { }
+    void
+    _XSetParams(xmlrpc_c::paramList& params)
+    { }
 
     // ---------------------------------------------
     // Recursively processes a parameter pack `args'
@@ -227,7 +233,8 @@ namespace ifm3d
     // `params' reference.
     // ---------------------------------------------
     template <typename T, typename... Args>
-    void _XSetParams(xmlrpc_c::paramList& params, T value, Args... args)
+    void
+    _XSetParams(xmlrpc_c::paramList& params, T value, Args... args)
     {
       params.addc(value);
       this->_XSetParams(params, args...);
@@ -258,11 +265,11 @@ namespace ifm3d
         {
           LOG(ERROR) << url << "->" << method << ":" << ex.what();
 
-          if (! rpc->isFinished())
+          if (!rpc->isFinished())
             {
               throw ifm3d::error_t(IFM3D_XMLRPC_TIMEOUT);
             }
-          else if (! rpc->isSuccessful())
+          else if (!rpc->isSuccessful())
             {
               xmlrpc_c::fault f = rpc->getFault();
               throw ifm3d::error_t(f.getCode());
@@ -298,9 +305,8 @@ namespace ifm3d
     xmlrpc_c::value const
     _XCallEdit(const std::string& method, Args... args)
     {
-      std::string url =
-        this->XPrefix() + ifm3d::XMLRPC_MAIN + ifm3d::XMLRPC_SESSION +
-        ifm3d::XMLRPC_EDIT;
+      std::string url = this->XPrefix() + ifm3d::XMLRPC_MAIN +
+                        ifm3d::XMLRPC_SESSION + ifm3d::XMLRPC_EDIT;
       return this->_XCall(url, method, args...);
     }
 
@@ -308,9 +314,9 @@ namespace ifm3d
     xmlrpc_c::value const
     _XCallDevice(const std::string& method, Args... args)
     {
-      std::string url =
-        this->XPrefix() + ifm3d::XMLRPC_MAIN + ifm3d::XMLRPC_SESSION +
-        ifm3d::XMLRPC_EDIT + ifm3d::XMLRPC_DEVICE;
+      std::string url = this->XPrefix() + ifm3d::XMLRPC_MAIN +
+                        ifm3d::XMLRPC_SESSION + ifm3d::XMLRPC_EDIT +
+                        ifm3d::XMLRPC_DEVICE;
       return this->_XCall(url, method, args...);
     }
 
@@ -318,9 +324,9 @@ namespace ifm3d
     xmlrpc_c::value const
     _XCallNet(const std::string& method, Args... args)
     {
-      std::string url =
-        this->XPrefix() + ifm3d::XMLRPC_MAIN + ifm3d::XMLRPC_SESSION +
-        ifm3d::XMLRPC_EDIT + ifm3d::XMLRPC_DEVICE + ifm3d::XMLRPC_NET;
+      std::string url = this->XPrefix() + ifm3d::XMLRPC_MAIN +
+                        ifm3d::XMLRPC_SESSION + ifm3d::XMLRPC_EDIT +
+                        ifm3d::XMLRPC_DEVICE + ifm3d::XMLRPC_NET;
       return this->_XCall(url, method, args...);
     }
 
@@ -328,9 +334,9 @@ namespace ifm3d
     xmlrpc_c::value const
     _XCallTime(const std::string& method, Args... args)
     {
-      std::string url =
-        this->XPrefix() + ifm3d::XMLRPC_MAIN + ifm3d::XMLRPC_SESSION +
-        ifm3d::XMLRPC_EDIT + ifm3d::XMLRPC_DEVICE + ifm3d::XMLRPC_TIME;
+      std::string url = this->XPrefix() + ifm3d::XMLRPC_MAIN +
+                        ifm3d::XMLRPC_SESSION + ifm3d::XMLRPC_EDIT +
+                        ifm3d::XMLRPC_DEVICE + ifm3d::XMLRPC_TIME;
       return this->_XCall(url, method, args...);
     }
 
@@ -338,9 +344,9 @@ namespace ifm3d
     xmlrpc_c::value const
     _XCallApp(const std::string& method, Args... args)
     {
-      std::string url =
-        this->XPrefix() + ifm3d::XMLRPC_MAIN + ifm3d::XMLRPC_SESSION +
-        ifm3d::XMLRPC_EDIT + ifm3d::XMLRPC_APP;
+      std::string url = this->XPrefix() + ifm3d::XMLRPC_MAIN +
+                        ifm3d::XMLRPC_SESSION + ifm3d::XMLRPC_EDIT +
+                        ifm3d::XMLRPC_APP;
       return this->_XCall(url, method, args...);
     }
 
@@ -348,9 +354,9 @@ namespace ifm3d
     xmlrpc_c::value const
     _XCallImager(const std::string& method, Args... args)
     {
-      std::string url =
-        this->XPrefix() + ifm3d::XMLRPC_MAIN + ifm3d::XMLRPC_SESSION +
-        ifm3d::XMLRPC_EDIT + ifm3d::XMLRPC_APP + ifm3d::XMLRPC_IMAGER;
+      std::string url = this->XPrefix() + ifm3d::XMLRPC_MAIN +
+                        ifm3d::XMLRPC_SESSION + ifm3d::XMLRPC_EDIT +
+                        ifm3d::XMLRPC_APP + ifm3d::XMLRPC_IMAGER;
       return this->_XCall(url, method, args...);
     }
 
@@ -358,10 +364,10 @@ namespace ifm3d
     xmlrpc_c::value const
     _XCallSpatialFilter(const std::string& method, Args... args)
     {
-      std::string url =
-        this->XPrefix() + ifm3d::XMLRPC_MAIN + ifm3d::XMLRPC_SESSION +
-        ifm3d::XMLRPC_EDIT + ifm3d::XMLRPC_APP + ifm3d::XMLRPC_IMAGER +
-        ifm3d::XMLRPC_SPATIALFILTER;
+      std::string url = this->XPrefix() + ifm3d::XMLRPC_MAIN +
+                        ifm3d::XMLRPC_SESSION + ifm3d::XMLRPC_EDIT +
+                        ifm3d::XMLRPC_APP + ifm3d::XMLRPC_IMAGER +
+                        ifm3d::XMLRPC_SPATIALFILTER;
       return this->_XCall(url, method, args...);
     }
 
@@ -369,10 +375,10 @@ namespace ifm3d
     xmlrpc_c::value const
     _XCallTemporalFilter(const std::string& method, Args... args)
     {
-      std::string url =
-        this->XPrefix() + ifm3d::XMLRPC_MAIN + ifm3d::XMLRPC_SESSION +
-        ifm3d::XMLRPC_EDIT + ifm3d::XMLRPC_APP + ifm3d::XMLRPC_IMAGER +
-        ifm3d::XMLRPC_TEMPORALFILTER;
+      std::string url = this->XPrefix() + ifm3d::XMLRPC_MAIN +
+                        ifm3d::XMLRPC_SESSION + ifm3d::XMLRPC_EDIT +
+                        ifm3d::XMLRPC_APP + ifm3d::XMLRPC_IMAGER +
+                        ifm3d::XMLRPC_TEMPORALFILTER;
       return this->_XCall(url, method, args...);
     }
 
@@ -396,10 +402,9 @@ ifm3d::Camera::Impl::Impl(const std::string& ip,
     password_(password),
     xmlrpc_url_prefix_("http://" + ip + ":" + std::to_string(xmlrpc_port)),
     xclient_(new xmlrpc_c::client_xml(
-               xmlrpc_c::clientXmlTransportPtr(
-                 new xmlrpc_c::clientXmlTransport_curl(
-                   xmlrpc_c::clientXmlTransport_curl::constrOpt().
-                   timeout(ifm3d::NET_WAIT))))),
+      xmlrpc_c::clientXmlTransportPtr(new xmlrpc_c::clientXmlTransport_curl(
+        xmlrpc_c::clientXmlTransport_curl::constrOpt().timeout(
+          ifm3d::NET_WAIT))))),
     session_("")
 {
   // Needed for fetching unit vectors over xmlrpc for O3X
@@ -407,8 +412,7 @@ ifm3d::Camera::Impl::Impl(const std::string& ip,
   xmlrpc_limit_set(XMLRPC_XML_SIZE_LIMIT_ID,
                    XMLRPC_XML_SIZE_LIMIT_DEFAULT * 2);
 
-  VLOG(IFM3D_TRACE) << "Initializing Camera: ip="
-                    << this->IP()
+  VLOG(IFM3D_TRACE) << "Initializing Camera: ip=" << this->IP()
                     << ", xmlrpc_port=" << this->XMLRPCPort()
                     << ", password=" << this->Password();
   VLOG(IFM3D_TRACE) << "XMLRPC URL Prefix=" << this->xmlrpc_url_prefix_;
@@ -469,8 +473,8 @@ ifm3d::Camera::Impl::SetSessionID(const std::string& id)
 std::unordered_map<std::string, std::string> const
 ifm3d::Camera::Impl::value_struct_to_map(const xmlrpc_c::value_struct& vs)
 {
-  std::map<std::string, xmlrpc_c::value> const
-    resmap(static_cast<std::map<std::string, xmlrpc_c::value> >(vs));
+  std::map<std::string, xmlrpc_c::value> const resmap(
+    static_cast<std::map<std::string, xmlrpc_c::value>>(vs));
 
   std::unordered_map<std::string, std::string> retval;
   for (auto& kv : resmap)
@@ -482,25 +486,22 @@ ifm3d::Camera::Impl::value_struct_to_map(const xmlrpc_c::value_struct& vs)
 }
 
 std::unordered_map<std::string,
-                   std::unordered_map<std::string, std::string> > const
+                   std::unordered_map<std::string, std::string>> const
 ifm3d::Camera::Impl::value_struct_to_map_of_maps(
   const xmlrpc_c::value_struct& vs)
 {
-  std::unordered_map<std::string,
-                     std::unordered_map<std::string, std::string> >
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
     retval;
 
-  std::map<std::string, xmlrpc_c::value> const
-    outter_map(static_cast<std::map<std::string, xmlrpc_c::value> >
-               (vs));
+  std::map<std::string, xmlrpc_c::value> const outter_map(
+    static_cast<std::map<std::string, xmlrpc_c::value>>(vs));
 
   for (auto& kv : outter_map)
     {
       xmlrpc_c::value_struct _vs(kv.second);
 
-      std::map<std::string, xmlrpc_c::value> const
-        inner_map(static_cast<std::map<std::string, xmlrpc_c::value> >
-                  (_vs));
+      std::map<std::string, xmlrpc_c::value> const inner_map(
+        static_cast<std::map<std::string, xmlrpc_c::value>>(_vs));
 
       std::unordered_map<std::string, std::string> inner_retval;
 
@@ -528,7 +529,8 @@ std::string
 ifm3d::Camera::Impl::DeviceParameter(const std::string& param)
 {
   return xmlrpc_c::value_string(
-           this->_XCallMain("getParameter", param.c_str())).cvalue();
+           this->_XCallMain("getParameter", param.c_str()))
+    .cvalue();
 }
 
 std::vector<std::string>
@@ -580,9 +582,8 @@ ifm3d::Camera::Impl::ApplicationList()
   for (auto& entry : res_vec)
     {
       xmlrpc_c::value_struct const entry_st(entry);
-      std::map<std::string, xmlrpc_c::value>
-        entry_map(static_cast<std::map<std::string, xmlrpc_c::value> >
-                  (entry_st));
+      std::map<std::string, xmlrpc_c::value> entry_map(
+        static_cast<std::map<std::string, xmlrpc_c::value>>(entry_st));
 
       ifm3d::app_entry_t app;
       app.index = xmlrpc_c::value_int(entry_map["Index"]).cvalue();
@@ -600,8 +601,7 @@ std::string
 ifm3d::Camera::Impl::RequestSession(const std::string& sid)
 {
   xmlrpc_c::value_string val_str(
-    this->_XCallMain("requestSession",
-                     this->Password().c_str(), sid));
+    this->_XCallMain("requestSession", this->Password().c_str(), sid));
 
   this->SetSessionID(static_cast<std::string>(val_str));
   this->Heartbeat(ifm3d::MAX_HEARTBEAT);
@@ -658,9 +658,8 @@ ifm3d::Camera::Impl::CancelSession()
     }
   catch (const ifm3d::error_t& ex)
     {
-      LOG(WARNING) << "Failed to cancel session: "
-                   << this->SessionID() << " -> "
-                   << ex.what();
+      LOG(WARNING) << "Failed to cancel session: " << this->SessionID()
+                   << " -> " << ex.what();
 
       if (ex.code() == IFM3D_XMLRPC_OBJ_NOT_FOUND)
         {
@@ -687,7 +686,8 @@ ifm3d::Camera::Impl::Heartbeat(int hb)
 }
 
 void
-ifm3d::Camera::Impl::SetOperatingMode(const ifm3d::Camera::operating_mode& mode)
+ifm3d::Camera::Impl::SetOperatingMode(
+  const ifm3d::Camera::operating_mode& mode)
 {
   this->_XCallSession("setOperatingMode", static_cast<int>(mode));
 }
@@ -706,19 +706,18 @@ ifm3d::Camera::Impl::SetTemporaryApplicationParameters(
           (kv.first == "imager_001/ExposureTimeRatio") ||
           (kv.first == "imager_001/Channel"))
         {
-          member =
-            std::make_pair(kv.first, xmlrpc_c::value_int(std::stoi(kv.second)));
+          member = std::make_pair(kv.first,
+                                  xmlrpc_c::value_int(std::stoi(kv.second)));
           param_map.insert(member);
         }
       else
         {
-        throw(ifm3d::error_t(IFM3D_INVALID_PARAM));
+          throw(ifm3d::error_t(IFM3D_INVALID_PARAM));
         }
     }
 
   xmlrpc_c::value_struct const params_st(param_map);
-  this->_XCallSession("setTemporaryApplicationParameters",
-                      params_st);
+  this->_XCallSession("setTemporaryApplicationParameters", params_st);
 }
 
 std::vector<std::uint8_t>
@@ -788,8 +787,8 @@ ifm3d::Camera::Impl::DeleteApplication(int idx)
 int
 ifm3d::Camera::Impl::CreateApplication(const std::string& type)
 {
-  xmlrpc_c::value_int
-    v_int(this->_XCallEdit("createApplication", type.c_str()));
+  xmlrpc_c::value_int v_int(
+    this->_XCallEdit("createApplication", type.c_str()));
   return v_int.cvalue();
 }
 
@@ -853,8 +852,8 @@ ifm3d::Camera::Impl::NetInfo()
 std::string
 ifm3d::Camera::Impl::NetParameter(const std::string& param)
 {
-  return xmlrpc_c::value_string(
-           this->_XCallNet("getParameter", param.c_str())).cvalue();
+  return xmlrpc_c::value_string(this->_XCallNet("getParameter", param.c_str()))
+    .cvalue();
 }
 
 void
@@ -884,7 +883,8 @@ std::string
 ifm3d::Camera::Impl::TimeParameter(const std::string& param)
 {
   return xmlrpc_c::value_string(
-           this->_XCallTime("getParameter", param.c_str())).cvalue();
+           this->_XCallTime("getParameter", param.c_str()))
+    .cvalue();
 }
 
 void
@@ -894,24 +894,23 @@ ifm3d::Camera::Impl::SetTimeParameter(const std::string& param,
   this->_XCallTime("setParameter", param.c_str(), val.c_str());
 }
 
-void ifm3d::Camera::Impl::SaveTime()
+void
+ifm3d::Camera::Impl::SaveTime()
 {
   this->_XCallTime("saveAndActivateConfig");
 }
-
 
 void
 ifm3d::Camera::Impl::SetCurrentTime(int epoch_seconds)
 {
   if (epoch_seconds < 0)
     {
-      epoch_seconds = static_cast<int>(
-                std::chrono::seconds(std::time(nullptr)).count());
+      epoch_seconds =
+        static_cast<int>(std::chrono::seconds(std::time(nullptr)).count());
     }
 
   this->_XCallTime("setCurrentTime", epoch_seconds);
 }
-
 
 // ---------------------------------------------
 // Application
@@ -926,8 +925,8 @@ ifm3d::Camera::Impl::AppInfo()
 std::string
 ifm3d::Camera::Impl::AppParameter(const std::string& param)
 {
-  return xmlrpc_c::value_string(
-           this->_XCallApp("getParameter", param.c_str())).cvalue();
+  return xmlrpc_c::value_string(this->_XCallApp("getParameter", param.c_str()))
+    .cvalue();
 }
 
 void
@@ -957,7 +956,8 @@ std::string
 ifm3d::Camera::Impl::ImagerParameter(const std::string& param)
 {
   return xmlrpc_c::value_string(
-           this->_XCallImager("getParameter", param.c_str())).cvalue();
+           this->_XCallImager("getParameter", param.c_str()))
+    .cvalue();
 }
 
 void
@@ -996,14 +996,15 @@ std::unordered_map<std::string, std::string>
 ifm3d::Camera::Impl::SpatialFilterInfo()
 {
   return this->value_struct_to_map(
-           this->_XCallSpatialFilter("getAllParameters"));
+    this->_XCallSpatialFilter("getAllParameters"));
 }
 
 std::string
 ifm3d::Camera::Impl::SpatialFilterParameter(const std::string& param)
 {
   return xmlrpc_c::value_string(
-           this->_XCallSpatialFilter("getParameter", param.c_str())).cvalue();
+           this->_XCallSpatialFilter("getParameter", param.c_str()))
+    .cvalue();
 }
 
 void
@@ -1021,19 +1022,20 @@ std::unordered_map<std::string, std::string>
 ifm3d::Camera::Impl::TemporalFilterInfo()
 {
   return this->value_struct_to_map(
-           this->_XCallTemporalFilter("getAllParameters"));
+    this->_XCallTemporalFilter("getAllParameters"));
 }
 
 std::string
 ifm3d::Camera::Impl::TemporalFilterParameter(const std::string& param)
 {
   return xmlrpc_c::value_string(
-           this->_XCallTemporalFilter("getParameter", param.c_str())).cvalue();
+           this->_XCallTemporalFilter("getParameter", param.c_str()))
+    .cvalue();
 }
 
 void
 ifm3d::Camera::Impl::SetTemporalFilterParameter(const std::string& param,
-                                               const std::string& val)
+                                                const std::string& val)
 {
   this->_XCallTemporalFilter("setParameter", param.c_str(), val.c_str());
 }

--- a/modules/camera/src/libifm3d_camera/err.cpp
+++ b/modules/camera/src/libifm3d_camera/err.cpp
@@ -74,7 +74,8 @@ const int IFM3D_LED_DUTY_CYCLE_VIOLATION = 101055;
 const int IFM3D_AUTO_EXPOSURE_NOT_SUPPORTED = 101056;
 const int IFM3D_INVALID_FIRMWARE_VERSION = 101058;
 
-const char *ifm3d::strerror(int errnum)
+const char*
+ifm3d::strerror(int errnum)
 {
   switch (errnum)
     {
@@ -88,7 +89,7 @@ const char *ifm3d::strerror(int errnum)
       return "Lib: Error processing JSON";
     case IFM3D_NO_ACTIVE_APPLICATION:
       return "Lib: No application is marked active";
-    case  IFM3D_SUBCOMMAND_ERROR:
+    case IFM3D_SUBCOMMAND_ERROR:
       return "Lib: Missing or invalid sub-command";
     case IFM3D_IO_ERROR:
       return "Lib: I/O error";
@@ -107,7 +108,8 @@ const char *ifm3d::strerror(int errnum)
     case IFM3D_UPDATE_ERROR:
       return "Lib: An error occured while performing the update";
     case IFM3D_RECOVERY_CONNECTION_ERROR:
-      return "Lib: Couldn't connect to the device (make sure the device is in Recovery Mode)";
+      return "Lib: Couldn't connect to the device (make sure the device is in "
+             "Recovery Mode)";
     case IFM3D_PCICCLIENT_UNSUPPORTED_DEVICE:
       return "Lib: PCICClient is not supported for this device";
     case IFM3D_INTRINSIC_CALIBRATION_UNSUPPORTED_DEVICE:
@@ -117,11 +119,13 @@ const char *ifm3d::strerror(int errnum)
     case IFM3D_CURL_ERROR:
       return "Lib: Encountered an unexpected error in the CURL library";
     case IFM3D_CURL_TIMEOUT:
-      return "Lib: An HTTP operation with CURL timed out. Can you 'ping' the camera?";
+      return "Lib: An HTTP operation with CURL timed out. Can you 'ping' the "
+             "camera?";
     case IFM3D_CURL_ABORTED:
       return "Lib: An HTTP operation with CURL was aborted.";
     case IFM3D_SWUPDATE_BAD_STATE:
-      return "Lib: SWUpdater process on camera is in invalid state. Reboot the camera and try again.";
+      return "Lib: SWUpdater process on camera is in invalid state. Reboot "
+             "the camera and try again.";
     case IFM3D_XMLRPC_OBJ_NOT_FOUND:
       return "Sensor: XMLRPC obj not found - trying to access dead session?";
     case IFM3D_INVALID_PARAM:
@@ -185,15 +189,16 @@ const char *ifm3d::strerror(int errnum)
     }
 }
 
-ifm3d::error_t::error_t(int errnum)
-  : std::exception(), errnum_(errnum) { }
+ifm3d::error_t::error_t(int errnum) : std::exception(), errnum_(errnum) { }
 
-int ifm3d::error_t::code() const noexcept
+int
+ifm3d::error_t::code() const noexcept
 {
   return this->errnum_;
 }
 
-const char *ifm3d::error_t::what() const noexcept
+const char*
+ifm3d::error_t::what() const noexcept
 {
   return ifm3d::strerror(this->code());
 }

--- a/modules/camera/src/libifm3d_camera/logging.cpp
+++ b/modules/camera/src/libifm3d_camera/logging.cpp
@@ -40,7 +40,8 @@ namespace ifm3d
     /**
      * Runs the one-time initialization code
      */
-    static void _Init(int verbose=0)
+    static void
+    _Init(int verbose = 0)
     {
       FLAGS_logbuflevel = -1;
       FLAGS_v = verbose;
@@ -56,7 +57,8 @@ namespace ifm3d
      *
      * @param[in] verbose glog's VLOG verbosity level
      */
-    static void Init(int verbose=0)
+    static void
+    Init(int verbose = 0)
     {
       std::call_once(ifm3d::Logging::init_, ifm3d::Logging::_Init, verbose);
     }
@@ -100,7 +102,8 @@ std::once_flag ifm3d::Logging::init_;
 INITIALIZER(libifm3d_camera_ctor)
 {
   int vlog = std::getenv("IFM3D_VLOG") == nullptr ?
-    0 : std::atoi(std::getenv("IFM3D_VLOG"));
+               0 :
+               std::atoi(std::getenv("IFM3D_VLOG"));
 
   ifm3d::Logging::Init(vlog);
 }

--- a/modules/camera/src/libifm3d_camera/logging.cpp
+++ b/modules/camera/src/libifm3d_camera/logging.cpp
@@ -67,7 +67,7 @@ namespace ifm3d
 
 std::once_flag ifm3d::Logging::init_;
 
-
+// clang-format off
 // Initializer sample for MSVC and GCC/Clang.
 // 2010-2016 Joe Lowe. Released into the public domain.
 #include <stdio.h>
@@ -95,7 +95,7 @@ std::once_flag ifm3d::Logging::init_;
         static void f(void) __attribute__((constructor)); \
         static void f(void)
 #endif
-
+// clang-format on
 
 INITIALIZER(libifm3d_camera_ctor)
 {

--- a/modules/camera/src/libifm3d_camera/util.cpp
+++ b/modules/camera/src/libifm3d_camera/util.cpp
@@ -33,7 +33,6 @@ ifm3d::rtrim(std::string& str, const std::string& chars)
   return str;
 }
 
-
 std::string&
 ifm3d::trim(std::string& str, const std::string& chars)
 {

--- a/modules/camera/src/libifm3d_camera/version.cpp
+++ b/modules/camera/src/libifm3d_camera/version.cpp
@@ -16,7 +16,8 @@
 
 #include <ifm3d/camera/version.h>
 
-void ifm3d::version(int *major, int *minor, int *patch)
+void
+ifm3d::version(int* major, int* minor, int* patch)
 {
   *major = IFM3D_VERSION_MAJOR;
   *minor = IFM3D_VERSION_MINOR;

--- a/modules/camera/test/ifm3d-camera-camera-tests.cpp
+++ b/modules/camera/test/ifm3d-camera-camera-tests.cpp
@@ -10,15 +10,15 @@
 class CameraTest : public ::testing::Test
 {
 protected:
-  virtual void SetUp()
+  virtual void
+  SetUp()
   {
     this->cam_ = ifm3d::Camera::MakeShared();
   }
 
-  virtual void TearDown()
-  {
-
-  }
+  virtual void
+  TearDown()
+  { }
 
   ifm3d::Camera::Ptr cam_;
 };
@@ -32,8 +32,7 @@ TEST_F(CameraTest, FactoryDefaults)
 
 TEST_F(CameraTest, DefaultCredentials)
 {
-  EXPECT_STREQ(this->cam_->IP().c_str(),
-               ifm3d::DEFAULT_IP.c_str());
+  EXPECT_STREQ(this->cam_->IP().c_str(), ifm3d::DEFAULT_IP.c_str());
   EXPECT_EQ(this->cam_->XMLRPCPort(), ifm3d::DEFAULT_XMLRPC_PORT);
   EXPECT_EQ(this->cam_->Password(), ifm3d::DEFAULT_PASSWORD);
 }
@@ -175,7 +174,7 @@ TEST_F(CameraTest, CreateDeleteApplication)
 
   int idx = -1;
   std::vector<std::string> app_types = this->cam_->ApplicationTypes();
-  for(auto& s : app_types)
+  for (auto& s : app_types)
     {
       idx = this->cam_->CreateApplication(s);
       app_list = this->cam_->ApplicationList();
@@ -189,8 +188,7 @@ TEST_F(CameraTest, CreateDeleteApplication)
 
 TEST_F(CameraTest, CreateApplicationException)
 {
-  EXPECT_THROW(this->cam_->CreateApplication("Foo"),
-               ifm3d::error_t);
+  EXPECT_THROW(this->cam_->CreateApplication("Foo"), ifm3d::error_t);
 }
 
 TEST_F(CameraTest, ImportExportApplication)
@@ -228,10 +226,9 @@ TEST_F(CameraTest, ImportExportConfig)
   std::vector<std::uint8_t> bytes;
 
   EXPECT_NO_THROW(bytes = this->cam_->ExportIFMConfig());
-  EXPECT_NO_THROW(
-    this->cam_->ImportIFMConfig(
-      bytes,
-      static_cast<std::uint16_t>(ifm3d::Camera::import_flags::GLOBAL)));
+  EXPECT_NO_THROW(this->cam_->ImportIFMConfig(
+    bytes,
+    static_cast<std::uint16_t>(ifm3d::Camera::import_flags::GLOBAL)));
 }
 
 TEST_F(CameraTest, ActiveApplication)
@@ -258,7 +255,7 @@ TEST_F(CameraTest, ActiveApplication)
   int idx = -1;
   for (auto& a : app_list)
     {
-      if (! a["Active"].get<bool>())
+      if (!a["Active"].get<bool>())
         {
           idx = a["Index"].get<int>();
           break;
@@ -356,12 +353,11 @@ TEST_F(CameraTest, Filters)
 
   int mask_size = static_cast<int>(ifm3d::Camera::mfilt_mask_size::_3x3);
 
-  if (! this->cam_->IsO3X())
+  if (!this->cam_->IsO3X())
     {
-       mask_size =
-         std::stoi(
-           dump["ifm3d"]["Apps"][0]["Imager"]["SpatialFilter"]["MaskSize"].
-           get<std::string>());
+      mask_size = std::stoi(
+        dump["ifm3d"]["Apps"][0]["Imager"]["SpatialFilter"]["MaskSize"]
+          .get<std::string>());
     }
 
   EXPECT_EQ(mask_size, static_cast<int>(ifm3d::Camera::mfilt_mask_size::_3x3));
@@ -384,12 +380,11 @@ TEST_F(CameraTest, Filters)
   dump = this->cam_->ToJSON();
   int n_imgs = 2; // default images number
 
-  if (! this->cam_->IsO3X())
+  if (!this->cam_->IsO3X())
     {
-     n_imgs =
-       std::stoi(
-         dump["ifm3d"]["Apps"][0]["Imager"]["TemporalFilter"]["NumberOfImages"].
-         get<std::string>());
+      n_imgs = std::stoi(
+        dump["ifm3d"]["Apps"][0]["Imager"]["TemporalFilter"]["NumberOfImages"]
+          .get<std::string>());
     }
 
   EXPECT_EQ(n_imgs, 2);
@@ -482,7 +477,8 @@ TEST_F(CameraTest, Time)
   EXPECT_NO_THROW(this->cam_->FromJSONStr(j));
   dump = this->cam_->ToJSON();
   ip = dump["ifm3d"]["Time"]["NTPServers"].get<std::string>();
-  active = dump["ifm3d"]["Time"]["SynchronizationActivated"].get<std::string>();
+  active =
+    dump["ifm3d"]["Time"]["SynchronizationActivated"].get<std::string>();
   EXPECT_STREQ("", ip.c_str());
   EXPECT_STREQ("false", active.c_str());
 
@@ -494,10 +490,8 @@ TEST_F(CameraTest, Time)
 
 TEST_F(CameraTest, TemporaryParameters)
 {
-  std::unordered_map<std::string, std::string> params =
-  {
-    { "imager_001/ExposureTime", "6000" }
-  };
+  std::unordered_map<std::string, std::string> params = {
+    {"imager_001/ExposureTime", "6000"}};
   cam_->RequestSession();
 
   EXPECT_NO_THROW(cam_->SetTemporaryApplicationParameters(params));

--- a/modules/camera/test/ifm3d-camera-testrunner.cpp
+++ b/modules/camera/test/ifm3d-camera-testrunner.cpp
@@ -1,7 +1,8 @@
 #include <ifm3d/camera.h>
 #include <gtest/gtest.h>
 
-int main(int argc, char **argv)
+int
+main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/modules/framegrabber/include/ifm3d/fg/byte_buffer.h
+++ b/modules/framegrabber/include/ifm3d/fg/byte_buffer.h
@@ -290,23 +290,39 @@ namespace ifm3d
      *
      * The elements are:
      *
-     * Name  Data type   Unit      Description
-     * fx    32 bit float  px        Focal length of the camera in the sensor's x axis direction.
-     * fy    32 bit float  px        Focal length of the camera in the sensor's y axis direction.
-     * mx    32 bit float  px        Main point in the sensor's x direction
-     * my    32 bit float  px        Main point in the sensor's y direction
-     * alpha 32 bit float  dimensionless Skew parameter
-     * k1    32 bit float  dimensionless First radial distortion coefficient
-     * k2    32 bit float  dimensionless Second radial distortion coefficient
-     * k5    32 bit float  dimensionless Third radial distortion coefficient
-     * k3    32 bit float  dimensionless First tangential distortion coefficient
-     * k4    32 bit float  dimensionless Second tangential distortion coefficient
-     * transX  32 bit float  mm        Translation along x-direction in meters.
-     * transY  32 bit float  mm        Translation along y-direction in meters.
-     * transZ  32 bit float  mm        Translation along z-direction in meters.
-     * rotX  32 bit float  degree        Rotation along x-axis in radians. Positive values indicate clockwise rotation.
-     * rotY  32 bit float  degree        Rotation along y-axis in radians. Positive values indicate clockwise rotation.
-     * rotZ  32 bit float  degree        Rotation along z-axis in radians. Positive values indicate clockwise rotation.
+     * Name    Data type     Unit           Description
+     * fx      32 bit float  px             Focal length of the camera in the
+     *                                      sensor's x axis direction.
+     * fy      32 bit float  px             Focal length of the camera in the
+     *                                      sensor's yaxis direction.
+     * mx      32 bit float  px             Main point in the sensor's x
+     *                                      direction
+     * my      32 bit float  px             Main point in the sensor's y
+     *                                      direction
+     * alpha   32 bit float  dimensionless  Skew parameter
+     * k1      32 bit float  dimensionless  First radial distortion coefficient
+     * k2      32 bit float  dimensionless  Second radial distortion
+     *                                      coefficient
+     * k5      32 bit float  dimensionless  Third radial distortion coefficient
+     * k3      32 bit float  dimensionless  First tangential distortion
+     *                                      coefficient
+     * k4      32 bit float  dimensionless  Second tangential distortion
+     *                                      coefficient
+     * transX  32 bit float  mm             Translation along x-direction in
+     *                                      meters.
+     * transY  32 bit float  mm             Translation along y-direction in
+     *                                      meters.
+     * transZ  32 bit float  mm             Translation along z-direction in
+     *                                      meters.
+     * rotX    32 bit float  degree         Rotation along x-axis in radians.
+     *                                      Positive values indicate clockwise
+     *                                      rotation.
+     * rotY    32 bit float  degree         Rotation along y-axis in radians.
+     *                                      Positive values indicate clockwise
+     *                                      rotation.
+     * rotZ    32 bit float  degree         Rotation along z-axis in radians.
+     *                                      Positive values indicate clockwise
+     *                                      rotation.
      *
      */
     std::vector<float> Intrinsics();

--- a/modules/framegrabber/include/ifm3d/fg/byte_buffer.h
+++ b/modules/framegrabber/include/ifm3d/fg/byte_buffer.h
@@ -29,9 +29,8 @@
 
 namespace ifm3d
 {
-  using TimePointT =
-    std::chrono::time_point<std::chrono::system_clock,
-                            std::chrono::nanoseconds>;
+  using TimePointT = std::chrono::time_point<std::chrono::system_clock,
+                                             std::chrono::nanoseconds>;
 
   extern IFM3D_FRAME_GRABBER_EXPORT const std::size_t IMG_TICKET_SZ; // bytes
   extern IFM3D_FRAME_GRABBER_EXPORT const std::size_t IMG_BUFF_START;
@@ -75,32 +74,38 @@ namespace ifm3d
   // intrinsic parameter
   enum class intrinsic_param : std::uint32_t
   {
-    F_X = 0,    //Focal length of the camera in the sensor's x axis direction.
-    F_Y = 1,    //Focal length of the camera in the sensor's y axis direction.
-    M_X = 2,    //Main point in the sensor's x direction
-    M_Y = 3,    //Main point in the sensor's x direction
-    ALPHA = 4,  //Skew parameter
-    K1 = 5,   //First radial distortion coefficient
-    K2 = 6,   //Second radial distortion coefficient
-    K5 = 7,   //Third radial distortion coefficient
-    K3 = 8,   //First tangential distortion coefficient
-    K4 = 9,   //Second tangential distortion coefficient
-    TRANS_X = 10, //Translation along x-direction in meters.
-    TRANS_Y = 11, //Translation along y-direction in meters.
-    TRANS_Z = 12, //Translation along Z-direction in meters.
-    ROT_X = 13, //Rotation along x-axis in radians. Positive values indicate clockwise rotation.
-    ROT_Y = 14, //Rotation along y-axis in radians. Positive values indicate clockwise rotation.
-    ROT_Z = 15  //Rotation along z-axis in radians. Positive values indicate clockwise rotation.
+    F_X = 0,   // Focal length of the camera in the sensor's x axis direction.
+    F_Y = 1,   // Focal length of the camera in the sensor's y axis direction.
+    M_X = 2,   // Main point in the sensor's x direction
+    M_Y = 3,   // Main point in the sensor's x direction
+    ALPHA = 4, // Skew parameter
+    K1 = 5,    // First radial distortion coefficient
+    K2 = 6,    // Second radial distortion coefficient
+    K5 = 7,    // Third radial distortion coefficient
+    K3 = 8,    // First tangential distortion coefficient
+    K4 = 9,    // Second tangential distortion coefficient
+    TRANS_X = 10, // Translation along x-direction in meters.
+    TRANS_Y = 11, // Translation along y-direction in meters.
+    TRANS_Z = 12, // Translation along Z-direction in meters.
+    ROT_X = 13,   // Rotation along x-axis in radians. Positive values indicate
+                  // clockwise rotation.
+    ROT_Y = 14,   // Rotation along y-axis in radians. Positive values indicate
+                  // clockwise rotation.
+    ROT_Z = 15    // Rotation along z-axis in radians. Positive values indicate
+                  // clockwise rotation.
   };
 
   enum class extrinsic_param : std::uint32_t
   {
-    TRANS_X = 0,  //Translation along x-direction in meters.
-    TRANS_Y = 1,  //Translation along y-direction in meters.
-    TRANS_Z = 2,  //Translation along Z-direction in meters.
-    ROT_X = 3,  //Rotation along x-axis in radians. Positive values indicate clockwise rotation.
-    ROT_Y = 4,  //Rotation along y-axis in radians. Positive values indicate clockwise rotation.
-    ROT_Z = 5   //Rotation along z-axis in radians. Positive values indicate clockwise rotation.
+    TRANS_X = 0, // Translation along x-direction in meters.
+    TRANS_Y = 1, // Translation along y-direction in meters.
+    TRANS_Z = 2, // Translation along Z-direction in meters.
+    ROT_X = 3,   // Rotation along x-axis in radians. Positive values indicate
+                 // clockwise rotation.
+    ROT_Y = 4,   // Rotation along y-axis in radians. Positive values indicate
+                 // clockwise rotation.
+    ROT_Z = 5    // Rotation along z-axis in radians. Positive values indicate
+                 // clockwise rotation.
   };
 
   /**
@@ -166,8 +171,9 @@ namespace ifm3d
    * @return An interpretation of `buff` as type T with bytes swapped as
    * appropriate for the host's byte ordering semantics.
    */
-  template<typename T>
-  T mkval(const unsigned char *buff)
+  template <typename T>
+  T
+  mkval(const unsigned char* buff)
   {
     union
     {
@@ -190,9 +196,9 @@ namespace ifm3d
    * the current schema mask set on the active framegrabber.
    *
    * The ByteBuffer imposes no specific image or point cloud data
-   * structure. This class is intended to be subclassed where more user-friendly
-   * data structures can be used to gain access to the bytes in a semantically
-   * meaningful manner.
+   * structure. This class is intended to be subclassed where more
+   * user-friendly data structures can be used to gain access to the bytes in a
+   * semantically meaningful manner.
    *
    * There are two primary interfaces (documented below) that image container
    * developers should implement. They are:
@@ -223,7 +229,7 @@ namespace ifm3d
   class ByteBuffer
   {
   public:
-    using Ptr = std::shared_ptr<ByteBuffer<Derived> >;
+    using Ptr = std::shared_ptr<ByteBuffer<Derived>>;
 
     /**
      * Default initializes instance vars
@@ -410,17 +416,24 @@ namespace ifm3d
      * @param[in] bytes A const reference to the byte buffer to process
      */
     template <typename T>
-    void ImCreate(ifm3d::image_chunk im,
-                  std::uint32_t fmt,
-                  std::size_t idx,
-                  std::uint32_t width,
-                  std::uint32_t height,
-                  int nchan,
-                  std::uint32_t npts,
-                  const std::vector<std::uint8_t>& bytes)
+    void
+    ImCreate(ifm3d::image_chunk im,
+             std::uint32_t fmt,
+             std::size_t idx,
+             std::uint32_t width,
+             std::uint32_t height,
+             int nchan,
+             std::uint32_t npts,
+             const std::vector<std::uint8_t>& bytes)
     {
-      static_cast<Derived *>(this)
-        ->template ImCreate<T>(im, fmt, idx, width, height, nchan, npts, bytes);
+      static_cast<Derived*>(this)->template ImCreate<T>(im,
+                                                        fmt,
+                                                        idx,
+                                                        width,
+                                                        height,
+                                                        nchan,
+                                                        npts,
+                                                        bytes);
     }
 
     /**
@@ -446,17 +459,24 @@ namespace ifm3d
      *
      */
     template <typename T>
-    void CloudCreate(std::uint32_t fmt,
-                     std::size_t xidx,
-                     std::size_t yidx,
-                     std::size_t zidx,
-                     std::uint32_t width,
-                     std::uint32_t height,
-                     std::uint32_t npts,
-                     const std::vector<std::uint8_t>& bytes)
+    void
+    CloudCreate(std::uint32_t fmt,
+                std::size_t xidx,
+                std::size_t yidx,
+                std::size_t zidx,
+                std::uint32_t width,
+                std::uint32_t height,
+                std::uint32_t npts,
+                const std::vector<std::uint8_t>& bytes)
     {
-      static_cast<Derived *>(this)
-        ->template CloudCreate<T>(fmt, xidx, yidx, zidx, width, height, npts, bytes);
+      static_cast<Derived*>(this)->template CloudCreate<T>(fmt,
+                                                           xidx,
+                                                           yidx,
+                                                           zidx,
+                                                           width,
+                                                           height,
+                                                           npts,
+                                                           bytes);
     }
 
     /**

--- a/modules/framegrabber/include/ifm3d/fg/detail/byte_buffer.hpp
+++ b/modules/framegrabber/include/ifm3d/fg/detail/byte_buffer.hpp
@@ -31,12 +31,14 @@
 template <typename Derived>
 ifm3d::ByteBuffer<Derived>::ByteBuffer()
   : dirty_(false),
-    extrinsics_({0.,0.,0.,0.,0.,0.}),
-    intrinsics_({0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.}),
-    inverseIntrinsics_({0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.}),
+    extrinsics_({0., 0., 0., 0., 0., 0.}),
+    intrinsics_(
+      {0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.}),
+    inverseIntrinsics_(
+      {0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.}),
     intrinsic_available(false),
     inverse_intrinsic_available(false),
-    exposure_times_({0,0,0}),
+    exposure_times_({0, 0, 0}),
     time_stamp_(std::chrono::system_clock::now()),
     json_model_("{}")
 { }
@@ -47,8 +49,7 @@ ifm3d::ByteBuffer<Derived>::~ByteBuffer() = default;
 
 // move ctor
 template <typename Derived>
-ifm3d::ByteBuffer<Derived>::ByteBuffer(
-  ifm3d::ByteBuffer<Derived>&& src_buff)
+ifm3d::ByteBuffer<Derived>::ByteBuffer(ifm3d::ByteBuffer<Derived>&& src_buff)
   : ifm3d::ByteBuffer<Derived>::ByteBuffer()
 {
   this->SetBytes(src_buff.bytes_, false);
@@ -57,8 +58,7 @@ ifm3d::ByteBuffer<Derived>::ByteBuffer(
 // move assignment
 template <typename Derived>
 ifm3d::ByteBuffer<Derived>&
-ifm3d::ByteBuffer<Derived>::operator= (
-  ifm3d::ByteBuffer<Derived>&& src_buff)
+ifm3d::ByteBuffer<Derived>::operator=(ifm3d::ByteBuffer<Derived>&& src_buff)
 {
   this->SetBytes(src_buff.bytes_, false);
   return *this;
@@ -77,7 +77,7 @@ ifm3d::ByteBuffer<Derived>::ByteBuffer(
 // copy assignment operator
 template <typename Derived>
 ifm3d::ByteBuffer<Derived>&
-ifm3d::ByteBuffer<Derived>::operator= (
+ifm3d::ByteBuffer<Derived>::operator=(
   const ifm3d::ByteBuffer<Derived>& src_buff)
 {
   if (this == &src_buff)
@@ -100,9 +100,7 @@ ifm3d::ByteBuffer<Derived>::SetBytes(std::vector<std::uint8_t>& buff,
       std::size_t sz = buff.size();
       this->bytes_.resize(sz);
 
-      std::copy(buff.begin(),
-                buff.begin() + sz,
-                this->bytes_.begin());
+      std::copy(buff.begin(), buff.begin() + sz, this->bytes_.begin());
     }
   else
     {
@@ -193,7 +191,7 @@ template <typename Derived>
 void
 ifm3d::ByteBuffer<Derived>::Organize()
 {
-  if (! this->Dirty())
+  if (!this->Dirty())
     {
       return;
     }
@@ -215,18 +213,18 @@ ifm3d::ByteBuffer<Derived>::Organize()
   std::size_t invintridx = INVALID_IDX;
   std::size_t jsonidx = INVALID_IDX;
 
-  xyzidx = ifm3d::get_chunk_index(this->bytes_,
-                                  ifm3d::image_chunk::CARTESIAN_ALL);
+  xyzidx =
+    ifm3d::get_chunk_index(this->bytes_, ifm3d::image_chunk::CARTESIAN_ALL);
   if (xyzidx == INVALID_IDX)
     {
-      xidx = ifm3d::get_chunk_index(this->bytes_,
-                                    ifm3d::image_chunk::CARTESIAN_X);
+      xidx =
+        ifm3d::get_chunk_index(this->bytes_, ifm3d::image_chunk::CARTESIAN_X);
 
-      yidx = ifm3d::get_chunk_index(this->bytes_,
-                                    ifm3d::image_chunk::CARTESIAN_Y);
+      yidx =
+        ifm3d::get_chunk_index(this->bytes_, ifm3d::image_chunk::CARTESIAN_Y);
 
-      zidx = ifm3d::get_chunk_index(this->bytes_,
-                                    ifm3d::image_chunk::CARTESIAN_Z);
+      zidx =
+        ifm3d::get_chunk_index(this->bytes_, ifm3d::image_chunk::CARTESIAN_Z);
     }
   else
     {
@@ -244,46 +242,41 @@ ifm3d::ByteBuffer<Derived>::Organize()
     }
 
   aidx = ifm3d::get_chunk_index(this->bytes_, ifm3d::image_chunk::AMPLITUDE);
-  raw_aidx = ifm3d::get_chunk_index(this->bytes_,
-                                    ifm3d::image_chunk::RAW_AMPLITUDE);
+  raw_aidx =
+    ifm3d::get_chunk_index(this->bytes_, ifm3d::image_chunk::RAW_AMPLITUDE);
   cidx = ifm3d::get_chunk_index(this->bytes_, ifm3d::image_chunk::CONFIDENCE);
-  didx = ifm3d::get_chunk_index(this->bytes_,
-                                ifm3d::image_chunk::RADIAL_DISTANCE);
-  uidx = ifm3d::get_chunk_index(this->bytes_,
-                                ifm3d::image_chunk::UNIT_VECTOR_ALL);
+  didx =
+    ifm3d::get_chunk_index(this->bytes_, ifm3d::image_chunk::RADIAL_DISTANCE);
+  uidx =
+    ifm3d::get_chunk_index(this->bytes_, ifm3d::image_chunk::UNIT_VECTOR_ALL);
   gidx = ifm3d::get_chunk_index(this->bytes_, ifm3d::image_chunk::GRAY);
   extidx = ifm3d::get_chunk_index(this->bytes_,
                                   ifm3d::image_chunk::EXTRINSIC_CALIBRATION);
-  jsonidx= ifm3d::get_chunk_index(this->bytes_,
-                                  ifm3d::image_chunk::JSON_MODEL);
+  jsonidx =
+    ifm3d::get_chunk_index(this->bytes_, ifm3d::image_chunk::JSON_MODEL);
 
   // As parameter will not change so only grabed and stored
   // for the first time
   if (!intrinsic_available)
     {
-      intridx = ifm3d::get_chunk_index(this->bytes_,
-                                      ifm3d::image_chunk::INTRINSIC_CALIBRATION);
+      intridx =
+        ifm3d::get_chunk_index(this->bytes_,
+                               ifm3d::image_chunk::INTRINSIC_CALIBRATION);
     }
 
-  if( !inverse_intrinsic_available )
-  {
-    invintridx = ifm3d::get_chunk_index(this->bytes_,
-                                  ifm3d::image_chunk::INVERSE_INTRINSIC_CALIBRATION);
-  }
+  if (!inverse_intrinsic_available)
+    {
+      invintridx = ifm3d::get_chunk_index(
+        this->bytes_,
+        ifm3d::image_chunk::INVERSE_INTRINSIC_CALIBRATION);
+    }
 
-
-  VLOG(IFM3D_PROTO_DEBUG) << "xyzidx=" << xyzidx
-                          << ", xidx=" << xidx
-                          << ", yidx=" << yidx
-                          << ", zidx=" << zidx
-                          << ", aidx=" << aidx
-                          << ", raw_aidx=" << raw_aidx
-                          << ", cidx=" << cidx
-                          << ", didx=" << didx
-                          << ", uidx=" << uidx
-                          << ", extidx=" << extidx
-                          << ", gidx=" << gidx
-                          << ", intridx=" << intridx
+  VLOG(IFM3D_PROTO_DEBUG) << "xyzidx=" << xyzidx << ", xidx=" << xidx
+                          << ", yidx=" << yidx << ", zidx=" << zidx
+                          << ", aidx=" << aidx << ", raw_aidx=" << raw_aidx
+                          << ", cidx=" << cidx << ", didx=" << didx
+                          << ", uidx=" << uidx << ", extidx=" << extidx
+                          << ", gidx=" << gidx << ", intridx=" << intridx
                           << ", invintridx=" << invintridx;
 
   // if we do not have a confidence image we cannot go further
@@ -294,15 +287,15 @@ ifm3d::ByteBuffer<Derived>::Organize()
     }
 
   const std::uint32_t header_version =
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+cidx+12);
+    ifm3d::mkval<std::uint32_t>(this->bytes_.data() + cidx + 12);
   // for the *big* time stamp minimum header version 2 is needed
   if (header_version > 1)
     {
       // Retrieve the timespamp information from the confidence data
       const std::uint32_t timestampSec =
-          ifm3d::mkval<std::uint32_t>(this->bytes_.data()+cidx+40);
+        ifm3d::mkval<std::uint32_t>(this->bytes_.data() + cidx + 40);
       const std::uint32_t timestampNsec =
-          ifm3d::mkval<std::uint32_t>(this->bytes_.data()+cidx+44);
+        ifm3d::mkval<std::uint32_t>(this->bytes_.data() + cidx + 44);
       // convert the time stamp into a TimePointT
       this->time_stamp_ =
         ifm3d::TimePointT{std::chrono::seconds{timestampSec} +
@@ -328,168 +321,201 @@ ifm3d::ByteBuffer<Derived>::Organize()
 
   // pixel format of each image
   std::uint32_t INVALID_FMT = std::numeric_limits<std::uint32_t>::max();
-  std::uint32_t cfmt = ifm3d::mkval<std::uint32_t>(this->bytes_.data()+cidx+24);
+  std::uint32_t cfmt =
+    ifm3d::mkval<std::uint32_t>(this->bytes_.data() + cidx + 24);
   std::uint32_t xfmt =
-    CART_OK ?
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+xidx+24) :
-    INVALID_FMT;
+    CART_OK ? ifm3d::mkval<std::uint32_t>(this->bytes_.data() + xidx + 24) :
+              INVALID_FMT;
   std::uint32_t yfmt =
-    CART_OK ?
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+yidx+24) :
-    INVALID_FMT;
+    CART_OK ? ifm3d::mkval<std::uint32_t>(this->bytes_.data() + yidx + 24) :
+              INVALID_FMT;
   std::uint32_t zfmt =
-    CART_OK ?
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+zidx+24) :
-    INVALID_FMT;
+    CART_OK ? ifm3d::mkval<std::uint32_t>(this->bytes_.data() + zidx + 24) :
+              INVALID_FMT;
   std::uint32_t afmt =
-    A_OK ?
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+aidx+24) :
-    INVALID_FMT;
+    A_OK ? ifm3d::mkval<std::uint32_t>(this->bytes_.data() + aidx + 24) :
+           INVALID_FMT;
   std::uint32_t raw_afmt =
     RAW_A_OK ?
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+raw_aidx+24) :
-    INVALID_FMT;
+      ifm3d::mkval<std::uint32_t>(this->bytes_.data() + raw_aidx + 24) :
+      INVALID_FMT;
   std::uint32_t dfmt =
-    D_OK ?
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+didx+24) :
-    INVALID_FMT;
+    D_OK ? ifm3d::mkval<std::uint32_t>(this->bytes_.data() + didx + 24) :
+           INVALID_FMT;
   std::uint32_t ufmt =
-    U_OK ?
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+uidx+24) :
-    INVALID_FMT;
+    U_OK ? ifm3d::mkval<std::uint32_t>(this->bytes_.data() + uidx + 24) :
+           INVALID_FMT;
   std::uint32_t extfmt =
-    EXT_OK ?
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+extidx+24) :
-    INVALID_FMT;
+    EXT_OK ? ifm3d::mkval<std::uint32_t>(this->bytes_.data() + extidx + 24) :
+             INVALID_FMT;
   std::uint32_t gfmt =
-    G_OK ?
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+gidx+24) :
-    INVALID_FMT;
+    G_OK ? ifm3d::mkval<std::uint32_t>(this->bytes_.data() + gidx + 24) :
+           INVALID_FMT;
   std::uint32_t intrfmt =
-    INTR_OK ?
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+intridx+24) :
-    INVALID_FMT;
+    INTR_OK ? ifm3d::mkval<std::uint32_t>(this->bytes_.data() + intridx + 24) :
+              INVALID_FMT;
   std::uint32_t invintrfmt =
     INVINTR_OK ?
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+invintridx+24) :
-    INVALID_FMT;
+      ifm3d::mkval<std::uint32_t>(this->bytes_.data() + invintridx + 24) :
+      INVALID_FMT;
 
-  VLOG(IFM3D_PROTO_DEBUG) << "xfmt=" << xfmt
-                          << ", yfmt=" << yfmt
-                          << ", zfmt=" << zfmt
-                          << ", afmt=" << afmt
-                          << ", raw_afmt=" << raw_afmt
-                          << ", cfmt=" << cfmt
-                          << ", dfmt=" << dfmt
-                          << ", ufmt=" << ufmt
-                          << ", extfmt=" << extfmt
-                          << ", gfmt=" << gfmt
+  VLOG(IFM3D_PROTO_DEBUG) << "xfmt=" << xfmt << ", yfmt=" << yfmt
+                          << ", zfmt=" << zfmt << ", afmt=" << afmt
+                          << ", raw_afmt=" << raw_afmt << ", cfmt=" << cfmt
+                          << ", dfmt=" << dfmt << ", ufmt=" << ufmt
+                          << ", extfmt=" << extfmt << ", gfmt=" << gfmt
                           << ", intrfmt= " << intrfmt
                           << ", invintrfmt= " << invintrfmt;
 
   // get the image dimensions
   std::uint32_t width =
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+cidx+16);
+    ifm3d::mkval<std::uint32_t>(this->bytes_.data() + cidx + 16);
   std::uint32_t height =
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+cidx+20);
+    ifm3d::mkval<std::uint32_t>(this->bytes_.data() + cidx + 20);
   std::uint32_t npts = width * height;
 
-  VLOG(IFM3D_PROTO_DEBUG) << "npts=" << npts
-                          << ", width x height="
-                          << width << " x " << height;
+  VLOG(IFM3D_PROTO_DEBUG) << "npts=" << npts << ", width x height=" << width
+                          << " x " << height;
 
-  auto im_wrapper =
-    [this, width, height, npts]
-    (ifm3d::image_chunk im, std::uint32_t fmt, std::size_t idx)
-    {
-      switch (fmt)
-        {
-        case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8U):
-          this->ImCreate<std::uint8_t>(
-            im, fmt, idx, width, height, 1, npts, this->bytes_);
-          break;
+  auto im_wrapper = [this, width, height, npts](ifm3d::image_chunk im,
+                                                std::uint32_t fmt,
+                                                std::size_t idx) {
+    switch (fmt)
+      {
+      case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8U):
+        this->ImCreate<std::uint8_t>(im,
+                                     fmt,
+                                     idx,
+                                     width,
+                                     height,
+                                     1,
+                                     npts,
+                                     this->bytes_);
+        break;
 
-        case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8S):
-          this->ImCreate<std::int8_t>(
-            im, fmt, idx, width, height, 1, npts, this->bytes_);
-          break;
+      case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8S):
+        this->ImCreate<std::int8_t>(im,
+                                    fmt,
+                                    idx,
+                                    width,
+                                    height,
+                                    1,
+                                    npts,
+                                    this->bytes_);
+        break;
 
-        case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_16U):
-          this->ImCreate<std::uint16_t>(
-            im, fmt, idx, width, height, 1, npts, this->bytes_);
-          break;
+      case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_16U):
+        this->ImCreate<std::uint16_t>(im,
+                                      fmt,
+                                      idx,
+                                      width,
+                                      height,
+                                      1,
+                                      npts,
+                                      this->bytes_);
+        break;
 
-        case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_16S):
-          this->ImCreate<std::int16_t>(
-            im, fmt, idx, width, height, 1, npts, this->bytes_);
-          break;
+      case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_16S):
+        this->ImCreate<std::int16_t>(im,
+                                     fmt,
+                                     idx,
+                                     width,
+                                     height,
+                                     1,
+                                     npts,
+                                     this->bytes_);
+        break;
 
-        case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32S):
-          this->ImCreate<std::int32_t>(
-            im, fmt, idx, width, height, 1, npts, this->bytes_);
-          break;
+      case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32S):
+        this->ImCreate<std::int32_t>(im,
+                                     fmt,
+                                     idx,
+                                     width,
+                                     height,
+                                     1,
+                                     npts,
+                                     this->bytes_);
+        break;
 
-        case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F):
-          this->ImCreate<float>(
-            im, fmt, idx, width, height, 1, npts, this->bytes_);
-          break;
+      case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F):
+        this->ImCreate<float>(im,
+                              fmt,
+                              idx,
+                              width,
+                              height,
+                              1,
+                              npts,
+                              this->bytes_);
+        break;
 
-        case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F3):
-          this->ImCreate<float>(
-            im, fmt, idx, width, height, 3, npts, this->bytes_);
-          break;
+      case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F3):
+        this->ImCreate<float>(im,
+                              fmt,
+                              idx,
+                              width,
+                              height,
+                              3,
+                              npts,
+                              this->bytes_);
+        break;
 
-        case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_64F):
-          this->ImCreate<double>(
-            im, fmt, idx, width, height, 1, npts, this->bytes_);
-          break;
+      case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_64F):
+        this->ImCreate<double>(im,
+                               fmt,
+                               idx,
+                               width,
+                               height,
+                               1,
+                               npts,
+                               this->bytes_);
+        break;
 
-        default:
-          LOG(ERROR) << "Cannot create image with pixel format = " << fmt;
-          throw ifm3d::error_t(IFM3D_PIXEL_FORMAT_ERROR);
-        }
-    };
+      default:
+        LOG(ERROR) << "Cannot create image with pixel format = " << fmt;
+        throw ifm3d::error_t(IFM3D_PIXEL_FORMAT_ERROR);
+      }
+  };
 
-  auto cloud_wrapper =
-    [this, width, height, npts]
-    (std::uint32_t fmt, std::size_t xidx, std::size_t yidx, std::size_t zidx)
-    {
-      switch (fmt)
-        {
-        case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_16S):
-          this->CloudCreate<std::int16_t>(fmt,            // pixel format
-                                          xidx,           // index of x-pix
-                                          yidx,           // index of y-pix
-                                          zidx,           // index of z-pix
-                                          width,          // n-cols
-                                          height,         // n-rows
-                                          npts,           // total points
-                                          this->bytes_);  // raw bytes
-          break;
+  auto cloud_wrapper = [this, width, height, npts](std::uint32_t fmt,
+                                                   std::size_t xidx,
+                                                   std::size_t yidx,
+                                                   std::size_t zidx) {
+    switch (fmt)
+      {
+      case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_16S):
+        this->CloudCreate<std::int16_t>(fmt,           // pixel format
+                                        xidx,          // index of x-pix
+                                        yidx,          // index of y-pix
+                                        zidx,          // index of z-pix
+                                        width,         // n-cols
+                                        height,        // n-rows
+                                        npts,          // total points
+                                        this->bytes_); // raw bytes
+        break;
 
-        case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F):
-          this->CloudCreate<float>(fmt,            // pixel format
-                                   xidx,           // index of x-pix
-                                   yidx,           // index of y-pix
-                                   zidx,           // index of z-pix
-                                   width,          // n-cols
-                                   height,         // n-rows
-                                   npts,           // total points
-                                   this->bytes_);  // raw bytes
-          break;
+      case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F):
+        this->CloudCreate<float>(fmt,           // pixel format
+                                 xidx,          // index of x-pix
+                                 yidx,          // index of y-pix
+                                 zidx,          // index of z-pix
+                                 width,         // n-cols
+                                 height,        // n-rows
+                                 npts,          // total points
+                                 this->bytes_); // raw bytes
+        break;
 
-        default:
-          LOG(ERROR) << "Cannot create cloud with pixel format = " << fmt;
-          throw ifm3d::error_t(IFM3D_PIXEL_FORMAT_ERROR);
-        }
-    };
+      default:
+        LOG(ERROR) << "Cannot create cloud with pixel format = " << fmt;
+        throw ifm3d::error_t(IFM3D_PIXEL_FORMAT_ERROR);
+      }
+  };
 
   //
   // Move index pointers to where the pixel data starts and parse
   // out the 2D image data
   //
   std::uint32_t pixel_data_offset =
-    ifm3d::mkval<std::uint32_t>(this->bytes_.data()+cidx+8);
+    ifm3d::mkval<std::uint32_t>(this->bytes_.data() + cidx + 8);
 
   cidx += pixel_data_offset;
   im_wrapper(ifm3d::image_chunk::CONFIDENCE, cfmt, cidx);
@@ -539,31 +565,32 @@ ifm3d::ByteBuffer<Derived>::Organize()
   //
   if (INTR_OK)
     {
-      //size of the chunk data
+      // size of the chunk data
       std::uint32_t chunk_size =
-      ifm3d::mkval<uint32_t >(this->bytes_.data() + intridx + 4);
+        ifm3d::mkval<uint32_t>(this->bytes_.data() + intridx + 4);
       intridx += pixel_data_offset;
       if (intrfmt !=
           static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F))
         {
-          LOG(ERROR) << "Intrinsic are expected to be float, not: "
-                     << intrfmt;
+          LOG(ERROR) << "Intrinsic are expected to be float, not: " << intrfmt;
           throw ifm3d::error_t(IFM3D_PIXEL_FORMAT_ERROR);
         }
-      if (header_version < 2 && (chunk_size - pixel_data_offset)
-          != ifm3d::NUM_INTRINSIC_PARAM * sizeof(uint32_t))
+      if (header_version < 2 &&
+          (chunk_size - pixel_data_offset) !=
+            ifm3d::NUM_INTRINSIC_PARAM * sizeof(uint32_t))
         {
           LOG(ERROR) << "Header Version expected value is >=2, not :"
                      << header_version
                      << "Intrinsic param dataLength expected value 64, not :"
                      << chunk_size - pixel_data_offset;
 
-        throw ifm3d::error_t(IFM3D_HEADER_VERSION_MISMATCH);
+          throw ifm3d::error_t(IFM3D_HEADER_VERSION_MISMATCH);
         }
-      for (std::size_t i = 0; i < ifm3d::NUM_INTRINSIC_PARAM; ++i, intridx += 4)
+      for (std::size_t i = 0; i < ifm3d::NUM_INTRINSIC_PARAM;
+           ++i, intridx += 4)
         {
           this->intrinsics_[i] =
-                ifm3d::mkval<float>(this->bytes_.data()+intridx);
+            ifm3d::mkval<float>(this->bytes_.data() + intridx);
         }
       this->intrinsic_available = true;
     }
@@ -573,9 +600,9 @@ ifm3d::ByteBuffer<Derived>::Organize()
   //
   if (INVINTR_OK)
     {
-      //size of the chunk data
+      // size of the chunk data
       std::uint32_t chunk_size =
-      ifm3d::mkval<uint32_t >(this->bytes_.data() + invintridx + 4);
+        ifm3d::mkval<uint32_t>(this->bytes_.data() + invintridx + 4);
       invintridx += pixel_data_offset;
       if (invintrfmt !=
           static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F))
@@ -584,41 +611,45 @@ ifm3d::ByteBuffer<Derived>::Organize()
                      << invintrfmt;
           throw ifm3d::error_t(IFM3D_PIXEL_FORMAT_ERROR);
         }
-      if (header_version < 2 && (chunk_size - pixel_data_offset)
-          != ifm3d::NUM_INTRINSIC_PARAM * sizeof(uint32_t))
+      if (header_version < 2 &&
+          (chunk_size - pixel_data_offset) !=
+            ifm3d::NUM_INTRINSIC_PARAM * sizeof(uint32_t))
         {
           LOG(ERROR) << "Header Version expected value is >=2, not :"
                      << header_version
                      << "Intrinsic param dataLength expected value 64, not :"
                      << chunk_size - pixel_data_offset;
 
-        throw ifm3d::error_t(IFM3D_HEADER_VERSION_MISMATCH);
+          throw ifm3d::error_t(IFM3D_HEADER_VERSION_MISMATCH);
         }
-      for (std::size_t i = 0; i < ifm3d::NUM_INTRINSIC_PARAM; ++i, invintridx += 4)
+      for (std::size_t i = 0; i < ifm3d::NUM_INTRINSIC_PARAM;
+           ++i, invintridx += 4)
         {
           this->inverseIntrinsics_[i] =
-                ifm3d::mkval<float>(this->bytes_.data()+invintridx);
+            ifm3d::mkval<float>(this->bytes_.data() + invintridx);
         }
       this->inverse_intrinsic_available = true;
     }
 
   if (JSON_OK)
-  {
-    std::uint32_t chunk_size =
-      ifm3d::mkval<uint32_t >(this->bytes_.data() + jsonidx + 4);
-    jsonidx += pixel_data_offset; // this is actually header size
-    this->json_model_.resize(chunk_size - pixel_data_offset);
-    std::memcpy((void*)this->json_model_.data(), (void*)(this->bytes_.data() + jsonidx), chunk_size - pixel_data_offset);
-  }
+    {
+      std::uint32_t chunk_size =
+        ifm3d::mkval<uint32_t>(this->bytes_.data() + jsonidx + 4);
+      jsonidx += pixel_data_offset; // this is actually header size
+      this->json_model_.resize(chunk_size - pixel_data_offset);
+      std::memcpy((void*)this->json_model_.data(),
+                  (void*)(this->bytes_.data() + jsonidx),
+                  chunk_size - pixel_data_offset);
+    }
 
   //
   // extrinsic calibration
   //
   if (EXT_OK)
     {
-      //size of the chunk data
+      // size of the chunk data
       std::uint32_t chunk_size =
-      ifm3d::mkval<uint32_t >(this->bytes_.data() + extidx + 4);
+        ifm3d::mkval<uint32_t>(this->bytes_.data() + extidx + 4);
       extidx += pixel_data_offset;
       if (extfmt !=
           static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F))
@@ -627,8 +658,9 @@ ifm3d::ByteBuffer<Derived>::Organize()
                      << extfmt;
           throw ifm3d::error_t(IFM3D_PIXEL_FORMAT_ERROR);
         }
-      if (header_version < 2 && (chunk_size - pixel_data_offset)
-         != ifm3d::NUM_EXTRINSIC_PARAM * sizeof(uint32_t))
+      if (header_version < 2 &&
+          (chunk_size - pixel_data_offset) !=
+            ifm3d::NUM_EXTRINSIC_PARAM * sizeof(uint32_t))
         {
           LOG(ERROR) << "Header Version expected value is >= 2, not :"
                      << header_version
@@ -640,9 +672,9 @@ ifm3d::ByteBuffer<Derived>::Organize()
       for (std::size_t i = 0; i < ifm3d::NUM_EXTRINSIC_PARAM; ++i, extidx += 4)
         {
           this->extrinsics_[i] =
-                ifm3d::mkval<float>(this->bytes_.data()+extidx);
+            ifm3d::mkval<float>(this->bytes_.data() + extidx);
         }
-  }
+    }
 
   // OK, now we want to see if the temp illu and exposure times are present,
   // if they are, we want to parse them out and store them registered to the
@@ -654,10 +686,9 @@ ifm3d::ByteBuffer<Derived>::Organize()
       size_t bytes_left = this->bytes_.size() - extime_idx;
 
       // Read extime (6 bytes string + 3x 4 bytes uint32_t)
-      if ((bytes_left >= 18) &&
-          std::equal(this->bytes_.begin() + extidx,
-                     this->bytes_.begin() + extidx + 6,
-                     std::begin("extime")))
+      if ((bytes_left >= 18) && std::equal(this->bytes_.begin() + extidx,
+                                           this->bytes_.begin() + extidx + 6,
+                                           std::begin("extime")))
         {
           extime_idx += 6;
           bytes_left -= 6;
@@ -671,7 +702,7 @@ ifm3d::ByteBuffer<Derived>::Organize()
                 }
 
               std::uint32_t extime2 =
-                  ifm3d::mkval<std::uint32_t>(this->bytes_.data() + extime_idx);
+                ifm3d::mkval<std::uint32_t>(this->bytes_.data() + extime_idx);
 
               this->exposure_times_.at(i) = extime2;
 
@@ -682,14 +713,14 @@ ifm3d::ByteBuffer<Derived>::Organize()
       else
         {
           std::fill(this->exposure_times_.begin(),
-                    this->exposure_times_.end(), 0);
+                    this->exposure_times_.end(),
+                    0);
         }
 
       // Read temp_illu (9 bytes string + 4 bytes float)
-      if ((bytes_left >= 13) &&
-          std::equal(this->bytes_.begin() + extidx,
-                     this->bytes_.begin() + extidx + 8,
-                     std::begin("temp_illu")))
+      if ((bytes_left >= 13) && std::equal(this->bytes_.begin() + extidx,
+                                           this->bytes_.begin() + extidx + 8,
+                                           std::begin("temp_illu")))
         {
           extime_idx += 9;
           bytes_left -= 9;

--- a/modules/framegrabber/include/ifm3d/fg/frame_grabber.h
+++ b/modules/framegrabber/include/ifm3d/fg/frame_grabber.h
@@ -106,18 +106,17 @@ namespace ifm3d
      *              otherwise.
      */
     template <typename T>
-    bool WaitForFrame(ifm3d::ByteBuffer<T>* buff,
-                      long timeout_millis = 0,
-                      bool copy_buff = false,
-                      bool organize = true)
+    bool
+    WaitForFrame(ifm3d::ByteBuffer<T>* buff,
+                 long timeout_millis = 0,
+                 bool copy_buff = false,
+                 bool organize = true)
     {
-      bool retval =
-        this->WaitForFrame(timeout_millis,
-                           [buff, copy_buff]
-                           (std::vector<std::uint8_t>& frame_data)
-                           {
-                             buff->SetBytes(frame_data, copy_buff);
-                           });
+      bool retval = this->WaitForFrame(
+        timeout_millis,
+        [buff, copy_buff](std::vector<std::uint8_t>& frame_data) {
+          buff->SetBytes(frame_data, copy_buff);
+        });
 
       // NOTE: it is an optimization to keep the call to Organize() outside of
       //       the lambda.
@@ -144,9 +143,9 @@ namespace ifm3d
      * @param[in] set_bytes A mutator function that will be called with the
      *                      latest frame data bytes from the camera.
      */
-    bool
-    WaitForFrame(long timeout_millis,
-                 std::function<void(std::vector<std::uint8_t>&)> set_bytes);
+    bool WaitForFrame(
+      long timeout_millis,
+      std::function<void(std::vector<std::uint8_t>&)> set_bytes);
 
   private:
     class Impl;

--- a/modules/framegrabber/include/ifm3d/fg/frame_grabber_export.h
+++ b/modules/framegrabber/include/ifm3d/fg/frame_grabber_export.h
@@ -7,7 +7,7 @@
 #  ifdef IFM3D_FRAME_GRABBER_DLL_BUILD
 #    define IFM3D_FRAME_GRABBER_EXPORT __declspec(dllexport)
 #  else
-#     define IFM3D_FRAME_GRABBER_EXPORT __declspec(dllimport)
+#    define IFM3D_FRAME_GRABBER_EXPORT __declspec(dllimport)
 #  endif
 #endif
 

--- a/modules/framegrabber/src/libifm3d_framegrabber/byte_buffer.cpp
+++ b/modules/framegrabber/src/libifm3d_framegrabber/byte_buffer.cpp
@@ -37,10 +37,8 @@ const std::size_t ifm3d::NUM_INTRINSIC_PARAM = 16;
 bool
 ifm3d::verify_ticket_buffer(const std::vector<std::uint8_t>& buff)
 {
-  return ((buff.size() == ifm3d::IMG_TICKET_SZ) &&
-          (buff.at(4) == 'L') &&
-          (buff.at(14) == '\r') &&
-          (buff.at(15) == '\n'));
+  return ((buff.size() == ifm3d::IMG_TICKET_SZ) && (buff.at(4) == 'L') &&
+          (buff.at(14) == '\r') && (buff.at(15) == '\n'));
 }
 
 bool
@@ -49,17 +47,16 @@ ifm3d::verify_image_buffer(const std::vector<std::uint8_t>& buff)
   std::size_t buff_sz = buff.size();
 
   return ((buff_sz > ifm3d::IMG_BUFF_START) &&
-          (std::string(buff.begin()+4,
-                       buff.begin()+ifm3d::IMG_BUFF_START) == "star") &&
-          (std::string(buff.end()-6, buff.end()-2) == "stop") &&
-          (buff.at(buff_sz - 2) == '\r') &&
-          (buff.at(buff_sz - 1) == '\n'));
+          (std::string(buff.begin() + 4,
+                       buff.begin() + ifm3d::IMG_BUFF_START) == "star") &&
+          (std::string(buff.end() - 6, buff.end() - 2) == "stop") &&
+          (buff.at(buff_sz - 2) == '\r') && (buff.at(buff_sz - 1) == '\n'));
 }
 
 std::size_t
 ifm3d::get_image_buffer_size(const std::vector<std::uint8_t>& buff)
 {
-  return std::stoi(std::string(buff.begin()+5, buff.end()));
+  return std::stoi(std::string(buff.begin() + 5, buff.end()));
 }
 
 std::size_t
@@ -68,22 +65,22 @@ ifm3d::get_chunk_index(const std::vector<std::uint8_t>& buff,
                        std::size_t start_idx)
 {
   std::size_t idx = start_idx; // start of first chunk
-  std::size_t size = buff.size()-6;
+  std::size_t size = buff.size() - 6;
 
   while (idx < size)
     {
       if (static_cast<std::uint32_t>(chunk_type) ==
-          ifm3d::mkval<std::uint32_t>(buff.data()+idx))
+          ifm3d::mkval<std::uint32_t>(buff.data() + idx))
         {
           return idx;
         }
 
       // move to the beginning of the next chunk
-      std::uint32_t incr = ifm3d::mkval<std::uint32_t>(buff.data()+idx+4);
+      std::uint32_t incr = ifm3d::mkval<std::uint32_t>(buff.data() + idx + 4);
       if (incr <= 0)
         {
-          LOG(WARNING) << "Next chunk is supposedly "
-                       << incr << " bytes from the current one ... failing!";
+          LOG(WARNING) << "Next chunk is supposedly " << incr
+                       << " bytes from the current one ... failing!";
           break;
         }
       idx += incr;

--- a/modules/framegrabber/src/libifm3d_framegrabber/frame_grabber.cpp
+++ b/modules/framegrabber/src/libifm3d_framegrabber/frame_grabber.cpp
@@ -23,8 +23,7 @@
 #include <ifm3d/camera/err.h>
 #include <frame_grabber_impl.hpp>
 
-ifm3d::FrameGrabber::FrameGrabber(ifm3d::Camera::Ptr cam,
-                                  std::uint16_t mask)
+ifm3d::FrameGrabber::FrameGrabber(ifm3d::Camera::Ptr cam, std::uint16_t mask)
   : pImpl(new ifm3d::FrameGrabber::Impl(cam, mask))
 { }
 

--- a/modules/framegrabber/src/libifm3d_framegrabber/frame_grabber_impl.hpp
+++ b/modules/framegrabber/src/libifm3d_framegrabber/frame_grabber_impl.hpp
@@ -144,8 +144,7 @@ namespace ifm3d
 //-------------------------------------
 // ctor/dtor
 //-------------------------------------
-ifm3d::FrameGrabber::Impl::Impl(ifm3d::Camera::Ptr cam,
-                                std::uint16_t mask)
+ifm3d::FrameGrabber::Impl::Impl(ifm3d::Camera::Ptr cam, std::uint16_t mask)
   : cam_(cam),
     mask_(mask),
     cam_ip_(this->cam_->IP()),
@@ -158,7 +157,7 @@ ifm3d::FrameGrabber::Impl::Impl(ifm3d::Camera::Ptr cam,
   this->SetTriggerBuffer();
   this->SetUVecBuffer(this->mask_);
 
-  if (! this->cam_->IsO3X())
+  if (!this->cam_->IsO3X())
     {
       try
         {
@@ -178,9 +177,9 @@ ifm3d::FrameGrabber::Impl::Impl(ifm3d::Camera::Ptr cam,
   LOG(INFO) << "Camera connection info: ip=" << this->cam_ip_
             << ", port=" << this->cam_port_;
 
-  this->endpoint_ =
-    boost::asio::ip::tcp::endpoint(
-      boost::asio::ip::address::from_string(this->cam_ip_), this->cam_port_);
+  this->endpoint_ = boost::asio::ip::tcp::endpoint(
+    boost::asio::ip::address::from_string(this->cam_ip_),
+    this->cam_port_);
 
   //
   // XXX: Make this work on older C++/gcc versions
@@ -188,9 +187,8 @@ ifm3d::FrameGrabber::Impl::Impl(ifm3d::Camera::Ptr cam,
   //  this->thread_ =
   //    std::make_unique<std::thread>(
   //      std::bind(&ifm3d::FrameGrabber::Impl::Run, this));
-  this->thread_ =
-    std::unique_ptr<std::thread>(
-      new std::thread(std::bind(&ifm3d::FrameGrabber::Impl::Run, this)));
+  this->thread_ = std::unique_ptr<std::thread>(
+    new std::thread(std::bind(&ifm3d::FrameGrabber::Impl::Run, this)));
 }
 
 ifm3d::FrameGrabber::Impl::~Impl()
@@ -220,7 +218,7 @@ ifm3d::FrameGrabber::Impl::SWTrigger()
         {
           this->cam_->ForceTrigger();
         }
-      catch(const ifm3d::error_t& ex)
+      catch (const ifm3d::error_t& ex)
         {
           LOG(ERROR) << "While trying to software trigger the camera: "
                      << ex.code() << " - " << ex.what();
@@ -233,7 +231,7 @@ ifm3d::FrameGrabber::Impl::SWTrigger()
   // For O3D and other bi-directional PCIC implementations
   //
   int i = 0;
-  while (! this->pcic_ready_.load())
+  while (!this->pcic_ready_.load())
     {
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
       i++;
@@ -245,19 +243,18 @@ ifm3d::FrameGrabber::Impl::SWTrigger()
         }
     }
 
-  this->io_service_.post(
-    [this]()
-    {
-      boost::asio::async_write(
-        this->sock_,
-        boost::asio::buffer(this->trigger_buffer_.data(),
-                            this->trigger_buffer_.size()),
-        [](const boost::system::error_code& ec,
-           std::size_t bytes_xferd)
-        {
-          if (ec) { throw ifm3d::error_t(ec.value()); }
-        });
-    });
+  this->io_service_.post([this]() {
+    boost::asio::async_write(
+      this->sock_,
+      boost::asio::buffer(this->trigger_buffer_.data(),
+                          this->trigger_buffer_.size()),
+      [](const boost::system::error_code& ec, std::size_t bytes_xferd) {
+        if (ec)
+          {
+            throw ifm3d::error_t(ec.value());
+          }
+      });
+  });
 }
 
 bool
@@ -275,11 +272,9 @@ ifm3d::FrameGrabber::Impl::WaitForFrame(
       // condition checked by the condition_variable predicate (pointer should
       // have changed) below
       std::uint8_t* initial_buff_ptr = this->front_buffer_.data();
-      auto predicate =
-        [this, initial_buff_ptr]()
-        {
-          return this->front_buffer_.data() != initial_buff_ptr;
-        };
+      auto predicate = [this, initial_buff_ptr]() {
+        return this->front_buffer_.data() != initial_buff_ptr;
+      };
 
       if (timeout_millis <= 0)
         {
@@ -335,7 +330,7 @@ ifm3d::FrameGrabber::Impl::SetUVecBuffer(std::uint16_t mask)
   // over XML-RPC
   //
 
-  if (! this->cam_->IsO3X())
+  if (!this->cam_->IsO3X())
     {
       return;
     }
@@ -356,8 +351,8 @@ ifm3d::FrameGrabber::Impl::SetUVecBuffer(std::uint16_t mask)
           std::size_t len = this->uvec_buffer_.size();
           for (std::size_t i = 0; i < len; ++i)
             {
-              ss << std::hex << std::setw(2)
-                 << std::setfill('0') << (int) this->uvec_buffer_.at(i);
+              ss << std::hex << std::setw(2) << std::setfill('0')
+                 << (int)this->uvec_buffer_.at(i);
 
               if (i < (len - 1))
                 {
@@ -366,8 +361,7 @@ ifm3d::FrameGrabber::Impl::SetUVecBuffer(std::uint16_t mask)
             }
           ss << "]";
 
-          VLOG(IFM3D_PROTO_DEBUG) << "Unit vectors: " << std::endl
-                                  << ss.str();
+          VLOG(IFM3D_PROTO_DEBUG) << "Unit vectors: " << std::endl << ss.str();
         }
     }
   catch (const ifm3d::error_t& ex)
@@ -377,74 +371,71 @@ ifm3d::FrameGrabber::Impl::SetUVecBuffer(std::uint16_t mask)
     }
 }
 
-
 void
 ifm3d::FrameGrabber::Impl::SetSchemaBuffer(std::uint16_t mask)
 {
-  if((mask & ifm3d::INTR_CAL) == ifm3d::INTR_CAL && (!this->cam_->IsO3D()))
+  if ((mask & ifm3d::INTR_CAL) == ifm3d::INTR_CAL && (!this->cam_->IsO3D()))
     {
       LOG(ERROR) << "Failed to set schema on O3X: "
                  << "Intrinsic parameter not supported by Device";
       throw ifm3d::error_t(IFM3D_INTRINSIC_CALIBRATION_UNSUPPORTED_DEVICE);
     }
 
-  if((mask & ifm3d::INTR_CAL) == ifm3d::INTR_CAL && this->cam_->IsO3D()
-     && ! this->cam_->CheckMinimumFirmwareVersion(
-                        ifm3d::O3D_INTRINSIC_PARAM_SUPPORT_MAJOR,
-                        ifm3d::O3D_INTRINSIC_PARAM_SUPPORT_MINOR,
-                        ifm3d::O3D_INTRINSIC_PARAM_SUPPORT_PATCH))
+  if ((mask & ifm3d::INTR_CAL) == ifm3d::INTR_CAL && this->cam_->IsO3D() &&
+      !this->cam_->CheckMinimumFirmwareVersion(
+        ifm3d::O3D_INTRINSIC_PARAM_SUPPORT_MAJOR,
+        ifm3d::O3D_INTRINSIC_PARAM_SUPPORT_MINOR,
+        ifm3d::O3D_INTRINSIC_PARAM_SUPPORT_PATCH))
     {
       LOG(ERROR) << "Failed to set schema on O3D: "
                  << "Intrinsic parameter not supported by Firmware";
       throw ifm3d::error_t(IFM3D_INTRINSIC_CALIBRATION_UNSUPPORTED_FIRMWARE);
     }
 
-  if(((mask & ifm3d::INV_INTR_CAL) == ifm3d::INV_INTR_CAL)
-     && (!this->cam_->IsO3D()))
-	  {
-	    LOG(ERROR) << "Failed to set schema on O3X: "
+  if (((mask & ifm3d::INV_INTR_CAL) == ifm3d::INV_INTR_CAL) &&
+      (!this->cam_->IsO3D()))
+    {
+      LOG(ERROR) << "Failed to set schema on O3X: "
                  << "Inverse intrinsic parameter not supported by Device";
-	    throw ifm3d::error_t(
-                    IFM3D_INVERSE_INTRINSIC_CALIBRATION_UNSUPPORTED_DEVICE);
-	  }
+      throw ifm3d::error_t(
+        IFM3D_INVERSE_INTRINSIC_CALIBRATION_UNSUPPORTED_DEVICE);
+    }
 
-  if((mask & ifm3d::INV_INTR_CAL) == ifm3d::INV_INTR_CAL && this->cam_->IsO3D()
-	   && !this->cam_->CheckMinimumFirmwareVersion(
-                       ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_MAJOR,
-                       ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_MINOR,
-                       ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_PATCH))
-	  {
-	    LOG(ERROR) << "Failed to set schema on O3D: "
+  if ((mask & ifm3d::INV_INTR_CAL) == ifm3d::INV_INTR_CAL &&
+      this->cam_->IsO3D() &&
+      !this->cam_->CheckMinimumFirmwareVersion(
+        ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_MAJOR,
+        ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_MINOR,
+        ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_PATCH))
+    {
+      LOG(ERROR) << "Failed to set schema on O3D: "
                  << "Inverse intrinsic parameter not supported by Firmware";
-	    throw ifm3d::error_t(
-                    IFM3D_INVERSE_INTRINSIC_CALIBRATION_UNSUPPORTED_FIRMWARE);
-	  }
+      throw ifm3d::error_t(
+        IFM3D_INVERSE_INTRINSIC_CALIBRATION_UNSUPPORTED_FIRMWARE);
+    }
 
-  if((mask & ifm3d::JSON_MODEL) == ifm3d::JSON_MODEL && (this->cam_->IsO3X()))
+  if ((mask & ifm3d::JSON_MODEL) == ifm3d::JSON_MODEL && (this->cam_->IsO3X()))
     {
       LOG(ERROR) << "Failed to set schema on O3X: "
                  << "json data not supported on O3X";
       throw ifm3d::error_t(IFM3D_INVALID_PARAM);
     }
 
-  if(this->cam_->IsO3X())
+  if (this->cam_->IsO3X())
     {
       // O3X does not set the schema via PCIC, rather we set it via
       // XMLRPC using the camera interface.
       // NOTE: Our internal `this->schema_buffer_` is not needed for O3X, so we
       // don't waste any time filling it.
       std::string o3xjson = ifm3d::make_o3x_json_from_mask(mask);
-      VLOG(IFM3D_PROTO_DEBUG) << "o3x schema: "
-                              << std::endl
-                              << o3xjson;
+      VLOG(IFM3D_PROTO_DEBUG) << "o3x schema: " << std::endl << o3xjson;
       try
         {
           this->cam_->FromJSONStr(o3xjson);
         }
       catch (const std::exception& ex)
         {
-          LOG(ERROR) << "Failed to set schema on O3X: "
-                     << ex.what();
+          LOG(ERROR) << "Failed to set schema on O3X: " << ex.what();
           LOG(WARNING) << "Running with currently applied schema";
         }
 
@@ -460,14 +451,10 @@ ifm3d::FrameGrabber::Impl::SetSchemaBuffer(std::uint16_t mask)
   std::string schema = ifm3d::make_schema(mask);
   std::size_t c_len = 4 + 1 + 9 + schema.size() + 2;
   std::ostringstream str;
-  str << ifm3d::TICKET_c
-      << 'L' << std::setfill('0') << std::setw(9) << c_len
+  str << ifm3d::TICKET_c << 'L' << std::setfill('0') << std::setw(9) << c_len
       << '\r' << '\n'
-      << ifm3d::TICKET_c << 'c'
-      << std::setfill('0') << std::setw(9)
-      << schema.size()
-      << schema
-      << '\r' << '\n';
+      << ifm3d::TICKET_c << 'c' << std::setfill('0') << std::setw(9)
+      << schema.size() << schema << '\r' << '\n';
 
   std::string c_command = str.str();
   this->schema_buffer_.assign(c_command.begin(), c_command.end());
@@ -486,8 +473,7 @@ ifm3d::FrameGrabber::Impl::SetTriggerBuffer()
 
   int t_len = 4 + 1 + 2;
   std::ostringstream str;
-  str << ifm3d::TICKET_t
-      << 'L' << std::setfill('0') << std::setw(9) << t_len
+  str << ifm3d::TICKET_t << 'L' << std::setfill('0') << std::setw(9) << t_len
       << '\r' << '\n'
       << ifm3d::TICKET_t << 't' << '\r' << '\n';
 
@@ -517,15 +503,16 @@ ifm3d::FrameGrabber::Impl::Run()
   // For non-O3X devices setting the schema via PCIC, we get acknowledgement of
   // our schema, then start processing the stream of pixel bytes
   auto result_schema_write_handler =
-    [this](const boost::system::error_code& ec, std::size_t bytes_xferd)
-    {
-      if (ec) { throw ifm3d::error_t(ec.value()); }
+    [this](const boost::system::error_code& ec, std::size_t bytes_xferd) {
+      if (ec)
+        {
+          throw ifm3d::error_t(ec.value());
+        }
       this->ticket_buffer_.clear();
       this->ticket_buffer_.resize(ifm3d::TICKET_ID_SZ);
 
       this->sock_.async_read_some(
-        boost::asio::buffer(this->ticket_buffer_.data(),
-                            ifm3d::TICKET_ID_SZ),
+        boost::asio::buffer(this->ticket_buffer_.data(), ifm3d::TICKET_ID_SZ),
         std::bind(&ifm3d::FrameGrabber::Impl::TicketHandler,
                   this,
                   std::placeholders::_1,
@@ -546,9 +533,11 @@ ifm3d::FrameGrabber::Impl::Run()
 
           this->sock_.async_connect(
             this->endpoint_,
-            [this](const boost::system::error_code& ec)
-            {
-              if (ec) { throw ifm3d::error_t(ec.value()); }
+            [this](const boost::system::error_code& ec) {
+              if (ec)
+                {
+                  throw ifm3d::error_t(ec.value());
+                }
               this->ticket_buffer_.clear();
               this->ticket_buffer_.resize(ifm3d::TICKET_ID_SZ);
 
@@ -568,9 +557,11 @@ ifm3d::FrameGrabber::Impl::Run()
           // we need to first write our desired schema to the camera
           this->sock_.async_connect(
             this->endpoint_,
-            [&, this](const boost::system::error_code& ec)
-            {
-              if (ec) { throw ifm3d::error_t(ec.value()); }
+            [&, this](const boost::system::error_code& ec) {
+              if (ec)
+                {
+                  throw ifm3d::error_t(ec.value());
+                }
               boost::asio::async_write(
                 this->sock_,
                 boost::asio::buffer(this->schema_buffer_.data(),
@@ -601,16 +592,18 @@ ifm3d::FrameGrabber::Impl::TicketHandler(const boost::system::error_code& ec,
                                          std::size_t bytes_xferd,
                                          std::size_t bytes_read)
 {
-  if (ec) { throw ifm3d::error_t(ec.value()); }
+  if (ec)
+    {
+      throw ifm3d::error_t(ec.value());
+    }
 
   bytes_read += bytes_xferd;
   if (bytes_read < ifm3d::TICKET_ID_SZ)
     {
-      bytes_read +=
-        boost::asio::read(
-          this->sock_,
-          boost::asio::buffer(&this->ticket_buffer_[bytes_read],
-                              ifm3d::TICKET_ID_SZ - bytes_read));
+      bytes_read += boost::asio::read(
+        this->sock_,
+        boost::asio::buffer(&this->ticket_buffer_[bytes_read],
+                            ifm3d::TICKET_ID_SZ - bytes_read));
 
       if (bytes_read != ifm3d::TICKET_ID_SZ)
         {
@@ -633,25 +626,23 @@ ifm3d::FrameGrabber::Impl::TicketHandler(const boost::system::error_code& ec,
     {
       this->ticket_buffer_.resize(ticket_sz + payload_sz);
 
-      bytes_read +=
-        boost::asio::read(
-          this->sock_,
-          boost::asio::buffer(&this->ticket_buffer_[bytes_read],
-                              (ticket_sz + payload_sz) - bytes_read));
+      bytes_read += boost::asio::read(
+        this->sock_,
+        boost::asio::buffer(&this->ticket_buffer_[bytes_read],
+                            (ticket_sz + payload_sz) - bytes_read));
 
       if (bytes_read != (ticket_sz + payload_sz))
         {
           LOG(ERROR) << "Timeout reading whole response!";
-          LOG(ERROR) << "Got " << bytes_read << " bytes of "
-                     << ticket_sz << " bytes expected";
+          LOG(ERROR) << "Got " << bytes_read << " bytes of " << ticket_sz
+                     << " bytes expected";
 
           throw ifm3d::error_t(IFM3D_IO_ERROR);
         }
     }
 
   std::string ticket_str;
-  ticket_str.assign(this->ticket_buffer_.begin(),
-                    this->ticket_buffer_.end());
+  ticket_str.assign(this->ticket_buffer_.begin(), this->ticket_buffer_.end());
   VLOG(IFM3D_PROTO_DEBUG) << "Full ticket: '" << ticket_str << "'";
 
   if (ticket == ifm3d::TICKET_image)
@@ -677,8 +668,7 @@ ifm3d::FrameGrabber::Impl::TicketHandler(const boost::system::error_code& ec,
           throw ifm3d::error_t(IFM3D_PCIC_BAD_REPLY);
         }
     }
-  else if ((ticket == ifm3d::TICKET_c) ||
-           (ticket == ifm3d::TICKET_t))
+  else if ((ticket == ifm3d::TICKET_c) || (ticket == ifm3d::TICKET_t))
     {
       if (this->ticket_buffer_.at(20) != '*')
         {
@@ -698,8 +688,7 @@ ifm3d::FrameGrabber::Impl::TicketHandler(const boost::system::error_code& ec,
       this->ticket_buffer_.clear();
       this->ticket_buffer_.resize(ifm3d::TICKET_ID_SZ);
       this->sock_.async_read_some(
-        boost::asio::buffer(this->ticket_buffer_.data(),
-                            ifm3d::TICKET_ID_SZ),
+        boost::asio::buffer(this->ticket_buffer_.data(), ifm3d::TICKET_ID_SZ),
         std::bind(&ifm3d::FrameGrabber::Impl::TicketHandler,
                   this,
                   std::placeholders::_1,
@@ -720,7 +709,10 @@ ifm3d::FrameGrabber::Impl::ImageHandler(const boost::system::error_code& ec,
                                         std::size_t bytes_xferd,
                                         std::size_t bytes_read)
 {
-  if (ec) { throw ifm3d::error_t(ec.value()); }
+  if (ec)
+    {
+      throw ifm3d::error_t(ec.value());
+    }
 
   bytes_read += bytes_xferd;
 
@@ -747,9 +739,10 @@ ifm3d::FrameGrabber::Impl::ImageHandler(const boost::system::error_code& ec,
           ((this->mask_ & ifm3d::IMG_UVEC) == ifm3d::IMG_UVEC))
         {
           VLOG(IFM3D_TRACE) << "Inserting unit vectors to front buffer";
-          this->front_buffer_.insert(
-            this->front_buffer_.begin()+ifm3d::IMG_BUFF_START,
-            this->uvec_buffer_.begin(), this->uvec_buffer_.end());
+          this->front_buffer_.insert(this->front_buffer_.begin() +
+                                       ifm3d::IMG_BUFF_START,
+                                     this->uvec_buffer_.begin(),
+                                     this->uvec_buffer_.end());
         }
       this->front_buffer_mutex_.unlock();
 
@@ -764,8 +757,7 @@ ifm3d::FrameGrabber::Impl::ImageHandler(const boost::system::error_code& ec,
   this->ticket_buffer_.clear();
   this->ticket_buffer_.resize(ifm3d::TICKET_ID_SZ);
   this->sock_.async_read_some(
-    boost::asio::buffer(this->ticket_buffer_.data(),
-                        ifm3d::TICKET_ID_SZ),
+    boost::asio::buffer(this->ticket_buffer_.data(), ifm3d::TICKET_ID_SZ),
     std::bind(&ifm3d::FrameGrabber::Impl::TicketHandler,
               this,
               std::placeholders::_1,

--- a/modules/framegrabber/src/libifm3d_framegrabber/schema.cpp
+++ b/modules/framegrabber/src/libifm3d_framegrabber/schema.cpp
@@ -21,31 +21,30 @@
 #include <vector>
 #include <ifm3d/camera/util.h>
 
-const std::uint16_t ifm3d::IMG_RDIS     = (1<<0); // 2**0
-const std::uint16_t ifm3d::IMG_AMP      = (1<<1); // 2**1
-const std::uint16_t ifm3d::IMG_RAMP     = (1<<2); // 2**2
-const std::uint16_t ifm3d::IMG_CART     = (1<<3); // 2**3
-const std::uint16_t ifm3d::IMG_UVEC     = (1<<4); // 2**4
-const std::uint16_t ifm3d::EXP_TIME     = (1<<5); // 2**5
-const std::uint16_t ifm3d::IMG_GRAY     = (1<<6); // 2**6
-const std::uint16_t ifm3d::ILLU_TEMP    = (1<<7); // 2**7
-const std::uint16_t ifm3d::INTR_CAL     = (1<<8); // 2**8
-const std::uint16_t ifm3d::INV_INTR_CAL = (1<<9); // 2**9
-const std::uint16_t ifm3d::JSON_MODEL   = (1<<10); // 2**10
+const std::uint16_t ifm3d::IMG_RDIS = (1 << 0);     // 2**0
+const std::uint16_t ifm3d::IMG_AMP = (1 << 1);      // 2**1
+const std::uint16_t ifm3d::IMG_RAMP = (1 << 2);     // 2**2
+const std::uint16_t ifm3d::IMG_CART = (1 << 3);     // 2**3
+const std::uint16_t ifm3d::IMG_UVEC = (1 << 4);     // 2**4
+const std::uint16_t ifm3d::EXP_TIME = (1 << 5);     // 2**5
+const std::uint16_t ifm3d::IMG_GRAY = (1 << 6);     // 2**6
+const std::uint16_t ifm3d::ILLU_TEMP = (1 << 7);    // 2**7
+const std::uint16_t ifm3d::INTR_CAL = (1 << 8);     // 2**8
+const std::uint16_t ifm3d::INV_INTR_CAL = (1 << 9); // 2**9
+const std::uint16_t ifm3d::JSON_MODEL = (1 << 10);  // 2**10
 
-auto __ifm3d_schema_mask__ = []()->std::uint16_t
-  {
-    try
-      {
-        return std::getenv("IFM3D_MASK") == nullptr ?
-            ifm3d::IMG_AMP|ifm3d::IMG_CART :
-            std::stoul(std::string(std::getenv("IFM3D_MASK"))) & 0xFFFF;
-      }
-    catch (const std::exception& /*ex*/)
-      {
-        return ifm3d::IMG_AMP|ifm3d::IMG_CART;
-      }
-  };
+auto __ifm3d_schema_mask__ = []() -> std::uint16_t {
+  try
+    {
+      return std::getenv("IFM3D_MASK") == nullptr ?
+               ifm3d::IMG_AMP | ifm3d::IMG_CART :
+               std::stoul(std::string(std::getenv("IFM3D_MASK"))) & 0xFFFF;
+    }
+  catch (const std::exception& /*ex*/)
+    {
+      return ifm3d::IMG_AMP | ifm3d::IMG_CART;
+    }
+};
 
 const std::uint16_t ifm3d::DEFAULT_SCHEMA_MASK = __ifm3d_schema_mask__();
 
@@ -53,82 +52,82 @@ std::string
 ifm3d::make_o3x_json_from_mask(std::uint16_t mask)
 {
   std::string schema =
-  R"(
+    R"(
       {
          "Apps":
          [
            {
              "Index":"1")";
 
-  if((mask & ifm3d::IMG_RDIS) == ifm3d::IMG_RDIS)
+  if ((mask & ifm3d::IMG_RDIS) == ifm3d::IMG_RDIS)
     {
       schema +=
-      R"(,
+        R"(,
              "OutputDistanceImage":"true")";
     }
   else
     {
       schema +=
-      R"(,
+        R"(,
              "OutputDistanceImage":"false")";
     }
 
-  if((mask & ifm3d::IMG_AMP) == ifm3d::IMG_AMP)
+  if ((mask & ifm3d::IMG_AMP) == ifm3d::IMG_AMP)
     {
       schema +=
-      R"(,
+        R"(,
              "OutputAmplitudeImage":"true")";
     }
   else
     {
       schema +=
-      R"(,
+        R"(,
              "OutputAmplitudeImage":"false")";
     }
 
-  if((mask & ifm3d::IMG_GRAY) == ifm3d::IMG_GRAY)
+  if ((mask & ifm3d::IMG_GRAY) == ifm3d::IMG_GRAY)
     {
       schema +=
-      R"(,
+        R"(,
              "OutputGrayscaleImage":"true")";
     }
   else
     {
       schema +=
-      R"(,
+        R"(,
              "OutputGrayscaleImage":"false")";
     }
 
-  if((mask & ifm3d::IMG_CART) == ifm3d::IMG_CART)
+  if ((mask & ifm3d::IMG_CART) == ifm3d::IMG_CART)
     {
       schema +=
-      R"(,
+        R"(,
              "OutputXYZImage":"true")";
     }
   else
     {
       schema +=
-      R"(,
+        R"(,
              "OutputXYZImage":"false")";
     }
 
-// Note: this is not yet supported by o3x
-//  if((mask & ifm3d::ILLU_TEMP) == ifm3d::ILLU_TEMP)
-//    {
-//      schema +=
-//      R"(,
-//             "OutputIlluminatorTemperature":"true")";
-//    }
-//  else
-//    {
-//      schema +=
-//      R"(,
-//             "OutputIlluminatorTemperature":"false")";
-//    }
+  // Note: this is not yet supported by o3x
+  //  if((mask & ifm3d::ILLU_TEMP) == ifm3d::ILLU_TEMP)
+  //    {
+  //      schema +=
+  //      R"(,
+  //             "OutputIlluminatorTemperature":"true")";
+  //    }
+  //  else
+  //    {
+  //      schema +=
+  //      R"(,
+  //             "OutputIlluminatorTemperature":"false")";
+  //    }
 
   // other invariants
   schema +=
-  R"(,
+    R"(,
              "OutputConfidenceImage":"true"
             }
          ]
@@ -142,7 +141,7 @@ std::string
 ifm3d::make_schema(std::uint16_t mask)
 {
   std::string schema =
-  R"(
+    R"(
       {
         "layouter": "flexible",
         "format"  : {"dataencoding":"ascii"},
@@ -150,47 +149,47 @@ ifm3d::make_schema(std::uint16_t mask)
          [
            {"type":"string", "value":"star", "id":"start_string"})";
 
-  if((mask & ifm3d::IMG_RDIS) == ifm3d::IMG_RDIS)
+  if ((mask & ifm3d::IMG_RDIS) == ifm3d::IMG_RDIS)
     {
       schema +=
-      R"(,
+        R"(,
            {"type":"blob", "id":"distance_image"})";
     }
 
-  if((mask & ifm3d::IMG_AMP) == ifm3d::IMG_AMP)
+  if ((mask & ifm3d::IMG_AMP) == ifm3d::IMG_AMP)
     {
       schema +=
-      R"(,
+        R"(,
            {"type":"blob", "id":"normalized_amplitude_image"})";
     }
 
-  if((mask & ifm3d::IMG_RAMP) == ifm3d::IMG_RAMP)
+  if ((mask & ifm3d::IMG_RAMP) == ifm3d::IMG_RAMP)
     {
       schema +=
-      R"(,
+        R"(,
            {"type":"blob", "id":"amplitude_image"})";
     }
 
-  if((mask & ifm3d::IMG_GRAY) == ifm3d::IMG_GRAY)
+  if ((mask & ifm3d::IMG_GRAY) == ifm3d::IMG_GRAY)
     {
       schema +=
-      R"(,
+        R"(,
            {"type":"blob", "id":"grayscale_image"})";
     }
 
-  if((mask & ifm3d::IMG_CART) == ifm3d::IMG_CART)
+  if ((mask & ifm3d::IMG_CART) == ifm3d::IMG_CART)
     {
       schema +=
-      R"(,
+        R"(,
            {"type":"blob", "id":"x_image"},
            {"type":"blob", "id":"y_image"},
            {"type":"blob", "id":"z_image"})";
     }
 
-  if((mask & ifm3d::IMG_UVEC) == ifm3d::IMG_UVEC)
+  if ((mask & ifm3d::IMG_UVEC) == ifm3d::IMG_UVEC)
     {
       schema +=
-      R"(,
+        R"(,
            {"type":"blob", "id":"all_unit_vector_matrices"})";
     }
 
@@ -198,7 +197,7 @@ ifm3d::make_schema(std::uint16_t mask)
   if ((mask & ifm3d::INTR_CAL) == ifm3d::INTR_CAL)
     {
       schema +=
-      R"(,
+        R"(,
            {"type":"blob", "id":"intrinsic_calibration"})";
     }
 
@@ -206,7 +205,7 @@ ifm3d::make_schema(std::uint16_t mask)
   if ((mask & ifm3d::INV_INTR_CAL) == ifm3d::INV_INTR_CAL)
     {
       schema +=
-      R"(,
+        R"(,
            {"type":"blob", "id":"inverse_intrinsic_calibration"})";
     }
 
@@ -223,10 +222,10 @@ ifm3d::make_schema(std::uint16_t mask)
            {"type":"blob", "id":"confidence_image"},
            {"type":"blob", "id":"extrinsic_calibration"})";
 
-  if((mask & ifm3d::EXP_TIME) == ifm3d::EXP_TIME)
+  if ((mask & ifm3d::EXP_TIME) == ifm3d::EXP_TIME)
     {
       schema +=
-      R"(,
+        R"(,
            {"type":"string", "id":"exposure_times", "value":"extime"},
            {
             "type":"uint32", "id":"exposure_time_1",
@@ -242,10 +241,10 @@ ifm3d::make_schema(std::uint16_t mask)
            })";
     }
 
-  if((mask & ifm3d::ILLU_TEMP) == ifm3d::ILLU_TEMP)
+  if ((mask & ifm3d::ILLU_TEMP) == ifm3d::ILLU_TEMP)
     {
       schema +=
-      R"(,
+        R"(,
            {"type":"string", "id":"temp_illu", "value":"temp_illu"},
            {
             "type":"float32", "id":"temp_illu",
@@ -255,7 +254,7 @@ ifm3d::make_schema(std::uint16_t mask)
 
   // other invariants
   schema +=
-  R"(,
+    R"(,
            {"type":"string", "value":"stop", "id":"end_string"}
          ]
       }
@@ -313,9 +312,9 @@ ifm3d::schema_mask_from_string(const std::string& in)
           mask |= ifm3d::INV_INTR_CAL;
         }
       else if (part == "JSON_MODEL")
-      {
-        mask |= ifm3d::JSON_MODEL;
-      }
+        {
+          mask |= ifm3d::JSON_MODEL;
+        }
     }
   return mask;
 }

--- a/modules/framegrabber/test/ifm3d-fg-testrunner.cpp
+++ b/modules/framegrabber/test/ifm3d-fg-testrunner.cpp
@@ -1,7 +1,8 @@
 #include <ifm3d/fg.h>
 #include <gtest/gtest.h>
 
-int main(int argc, char **argv)
+int
+main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/modules/framegrabber/test/ifm3d-fg-tests.cpp
+++ b/modules/framegrabber/test/ifm3d-fg-tests.cpp
@@ -18,37 +18,35 @@
 class MyBuff : public ifm3d::ByteBuffer<MyBuff>
 {
 public:
-  MyBuff() : ifm3d::ByteBuffer<MyBuff>()
+  MyBuff() : ifm3d::ByteBuffer<MyBuff>() { LOG(INFO) << "ctor"; }
+
+  template <typename T>
+  void
+  ImCreate(ifm3d::image_chunk im,
+           std::uint32_t fmt,
+           std::size_t idx,
+           std::uint32_t width,
+           std::uint32_t height,
+           int nchan,
+           std::uint32_t npts,
+           const std::vector<std::uint8_t>& bytes)
   {
-    LOG(INFO) << "ctor";
+    LOG(INFO) << "ImCreate: " << (int)im;
   }
 
   template <typename T>
-  void ImCreate(ifm3d::image_chunk im,
-                std::uint32_t fmt,
-                std::size_t idx,
-                std::uint32_t width,
-                std::uint32_t height,
-                int nchan,
-                std::uint32_t npts,
-                const std::vector<std::uint8_t>& bytes)
-  {
-    LOG(INFO) << "ImCreate: " << (int) im;
-  }
-
-  template <typename T>
-  void CloudCreate(std::uint32_t fmt,
-                   std::size_t xidx,
-                   std::size_t yidx,
-                   std::size_t zidx,
-                   std::uint32_t width,
-                   std::uint32_t height,
-                   std::uint32_t npts,
-                   const std::vector<std::uint8_t>& bytes)
+  void
+  CloudCreate(std::uint32_t fmt,
+              std::size_t xidx,
+              std::size_t yidx,
+              std::size_t zidx,
+              std::uint32_t width,
+              std::uint32_t height,
+              std::uint32_t npts,
+              const std::vector<std::uint8_t>& bytes)
   {
     LOG(INFO) << "CloudCreate";
   }
-
 };
 
 TEST(FrameGrabber, FactoryDefaults)
@@ -73,7 +71,9 @@ TEST(FrameGrabber, ByteBufferBasics)
   std::vector<float> inverseIntrinsic = buff->InverseIntrinsics();
 
   EXPECT_TRUE(std::equal(intrinsic.begin(), intrinsic.end(), zeros.begin()));
-  EXPECT_TRUE(std::equal(inverseIntrinsic.begin(), inverseIntrinsic.end(), zeros.begin()));
+  EXPECT_TRUE(std::equal(inverseIntrinsic.begin(),
+                         inverseIntrinsic.end(),
+                         zeros.begin()));
   EXPECT_TRUE(std::equal(extrinsics.begin(), extrinsics.end(), zeros.begin()));
   EXPECT_TRUE(std::equal(exposures.begin(), exposures.end(), zeros.begin()));
 }
@@ -98,7 +98,7 @@ TEST(FrameGrabber, WaitForFrame)
 TEST(FrameGrabber, CustomSchema)
 {
   LOG(INFO) << "CustomSchema test";
-  std::uint16_t mask = ifm3d::IMG_AMP|ifm3d::IMG_RDIS|ifm3d::IMG_UVEC;
+  std::uint16_t mask = ifm3d::IMG_AMP | ifm3d::IMG_RDIS | ifm3d::IMG_UVEC;
 
   auto cam = ifm3d::Camera::MakeShared();
   auto fg = std::make_shared<ifm3d::FrameGrabber>(cam, mask);
@@ -110,67 +110,66 @@ TEST(FrameGrabber, CustomSchema)
 TEST(FrameGrabber, IntrinsicParamSchema)
 {
   LOG(INFO) << "IntrinsicParamSchema test";
-  std::uint16_t mask = ifm3d::IMG_AMP|ifm3d::IMG_RDIS|ifm3d::INTR_CAL;
+  std::uint16_t mask = ifm3d::IMG_AMP | ifm3d::IMG_RDIS | ifm3d::INTR_CAL;
 
   auto cam = ifm3d::Camera::MakeShared();
-  if(cam->IsO3X()) // intrinsic parameter  not supported
-   {
-     EXPECT_THROW(std::make_shared<ifm3d::FrameGrabber>(cam, mask),
-                  ifm3d::error_t);
-   }
-  if(cam->IsO3D() &&
-     cam->CheckMinimumFirmwareVersion(
-       ifm3d::O3D_INTRINSIC_PARAM_SUPPORT_MAJOR,
-       ifm3d::O3D_INTRINSIC_PARAM_SUPPORT_MINOR,
-       ifm3d::O3D_INTRINSIC_PARAM_SUPPORT_PATCH))
-   {
-     auto fg = std::make_shared<ifm3d::FrameGrabber>(cam,mask);
-     auto buff = std::make_shared<MyBuff>();
-     EXPECT_TRUE(fg->WaitForFrame(buff.get(), 1000));
-   }
-  else if(cam->IsO3D())
-   {
-     EXPECT_THROW(std::make_shared<ifm3d::FrameGrabber>(cam, mask),
-                  ifm3d::error_t);
-   }
+  if (cam->IsO3X()) // intrinsic parameter  not supported
+    {
+      EXPECT_THROW(std::make_shared<ifm3d::FrameGrabber>(cam, mask),
+                   ifm3d::error_t);
+    }
+  if (cam->IsO3D() && cam->CheckMinimumFirmwareVersion(
+                        ifm3d::O3D_INTRINSIC_PARAM_SUPPORT_MAJOR,
+                        ifm3d::O3D_INTRINSIC_PARAM_SUPPORT_MINOR,
+                        ifm3d::O3D_INTRINSIC_PARAM_SUPPORT_PATCH))
+    {
+      auto fg = std::make_shared<ifm3d::FrameGrabber>(cam, mask);
+      auto buff = std::make_shared<MyBuff>();
+      EXPECT_TRUE(fg->WaitForFrame(buff.get(), 1000));
+    }
+  else if (cam->IsO3D())
+    {
+      EXPECT_THROW(std::make_shared<ifm3d::FrameGrabber>(cam, mask),
+                   ifm3d::error_t);
+    }
 }
 
 TEST(FrameGrabber, InverseIntrinsicParamSchema)
 {
   LOG(INFO) << "InverseIntrinsicParamSchema test";
 
-  std::uint16_t mask = (ifm3d::IMG_AMP|ifm3d::IMG_RDIS|
-                        ifm3d::INTR_CAL|ifm3d::INV_INTR_CAL);
+  std::uint16_t mask =
+    (ifm3d::IMG_AMP | ifm3d::IMG_RDIS | ifm3d::INTR_CAL | ifm3d::INV_INTR_CAL);
   auto cam = ifm3d::Camera::MakeShared();
-  if(cam->IsO3X()) // inverse intrinsic parameter  not supported
-   {
-     EXPECT_THROW(std::make_shared<ifm3d::FrameGrabber>(cam, mask),
-                  ifm3d::error_t);
-   }
-  if(cam->IsO3D() &&
-     cam->CheckMinimumFirmwareVersion(
-       ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_MAJOR,
-       ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_MINOR,
-       ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_PATCH))
-   {
-     auto fg = std::make_shared<ifm3d::FrameGrabber>(cam,mask);
-     auto buff = std::make_shared<MyBuff>();
+  if (cam->IsO3X()) // inverse intrinsic parameter  not supported
+    {
+      EXPECT_THROW(std::make_shared<ifm3d::FrameGrabber>(cam, mask),
+                   ifm3d::error_t);
+    }
+  if (cam->IsO3D() && cam->CheckMinimumFirmwareVersion(
+                        ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_MAJOR,
+                        ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_MINOR,
+                        ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_PATCH))
+    {
+      auto fg = std::make_shared<ifm3d::FrameGrabber>(cam, mask);
+      auto buff = std::make_shared<MyBuff>();
 
-     EXPECT_TRUE(fg->WaitForFrame(buff.get(), 1000));
+      EXPECT_TRUE(fg->WaitForFrame(buff.get(), 1000));
 
-     std::vector<float> intrinsics=buff->Intrinsics();
-     EXPECT_TRUE(std::accumulate(intrinsics.begin(),
-                                 intrinsics.end(), 0.) > 0.);
+      std::vector<float> intrinsics = buff->Intrinsics();
+      EXPECT_TRUE(std::accumulate(intrinsics.begin(), intrinsics.end(), 0.) >
+                  0.);
 
-     std::vector<float> inverseIntrinsics=buff->InverseIntrinsics();
-     EXPECT_TRUE(std::accumulate(inverseIntrinsics.begin(),
-                                 inverseIntrinsics.end(), 0.) > 0.);
-   }
-  else if(cam->IsO3D())
-   {
-     EXPECT_THROW(std::make_shared<ifm3d::FrameGrabber>(cam, mask),
-                  ifm3d::error_t);
-   }
+      std::vector<float> inverseIntrinsics = buff->InverseIntrinsics();
+      EXPECT_TRUE(std::accumulate(inverseIntrinsics.begin(),
+                                  inverseIntrinsics.end(),
+                                  0.) > 0.);
+    }
+  else if (cam->IsO3D())
+    {
+      EXPECT_THROW(std::make_shared<ifm3d::FrameGrabber>(cam, mask),
+                   ifm3d::error_t);
+    }
 }
 
 TEST(FrameGrabber, ByteBufferMoveCtor)
@@ -247,7 +246,7 @@ TEST(FrameGrabber, FrameGrabberRecycling)
       EXPECT_TRUE(fg->WaitForFrame(buff.get(), 1000));
     }
 
-  if (! cam->IsO3X())
+  if (!cam->IsO3X())
     {
       fg.reset(new ifm3d::FrameGrabber(cam));
       for (int i = 0; i < 5; ++i)
@@ -284,7 +283,7 @@ TEST(FrameGrabber, SoftwareTrigger)
   // mark the current active application as sw triggered
   int idx = cam->ActiveApplication();
   json config = cam->ToJSON();
-  config["ifm3d"]["Apps"][idx-1]["TriggerMode"] =
+  config["ifm3d"]["Apps"][idx - 1]["TriggerMode"] =
     std::to_string(static_cast<int>(ifm3d::Camera::trigger_mode::SW));
   cam->FromJSON(config);
 
@@ -299,11 +298,10 @@ TEST(FrameGrabber, SoftwareTrigger)
     {
       fg->SWTrigger();
       EXPECT_TRUE(fg->WaitForFrame(buff.get(), 1000));
-
     }
 
   // set the camera back into free-run mode
-  config["ifm3d"]["Apps"][idx-1]["TriggerMode"] =
+  config["ifm3d"]["Apps"][idx - 1]["TriggerMode"] =
     std::to_string(static_cast<int>(ifm3d::Camera::trigger_mode::FREE_RUN));
   cam->FromJSON(config);
 }
@@ -325,7 +323,7 @@ TEST(FrameGrabber, SWTriggerMultipleClients)
   // mark the current active application as sw triggered
   int idx = cam->ActiveApplication();
   json config = cam->ToJSON();
-  config["ifm3d"]["Apps"][idx-1]["TriggerMode"] =
+  config["ifm3d"]["Apps"][idx - 1]["TriggerMode"] =
     std::to_string(static_cast<int>(ifm3d::Camera::trigger_mode::SW));
   cam->FromJSON(config);
 
@@ -338,12 +336,12 @@ TEST(FrameGrabber, SWTriggerMultipleClients)
 
   // launch two threads where each of the framegrabbers will
   // wait for a new frame
-  auto fut1 = std::async(std::launch::async,
-                         [fg1,buff1]()->bool
-                         {return fg1->WaitForFrame(buff1.get(),5000);});
-  auto fut2 = std::async(std::launch::async,
-                         [fg2,buff2]()->bool
-                         {return fg2->WaitForFrame(buff2.get(),5000);});
+  auto fut1 = std::async(std::launch::async, [fg1, buff1]() -> bool {
+    return fg1->WaitForFrame(buff1.get(), 5000);
+  });
+  auto fut2 = std::async(std::launch::async, [fg2, buff2]() -> bool {
+    return fg2->WaitForFrame(buff2.get(), 5000);
+  });
 
   // Let's S/W trigger from the first -- this could have been a third
   // framegrabber (i.e., client to PCIC)
@@ -357,7 +355,7 @@ TEST(FrameGrabber, SWTriggerMultipleClients)
   EXPECT_TRUE(buff1->Bytes() == buff2->Bytes());
 
   // set the camera back into free-run mode
-  config["ifm3d"]["Apps"][idx-1]["TriggerMode"] =
+  config["ifm3d"]["Apps"][idx - 1]["TriggerMode"] =
     std::to_string(static_cast<int>(ifm3d::Camera::trigger_mode::FREE_RUN));
   cam->FromJSON(config);
 }
@@ -371,7 +369,7 @@ TEST(FrameGrabber, JSON_model)
   if (cam->IsO3X()) // JSON model not supported
     {
       EXPECT_THROW(std::make_shared<ifm3d::FrameGrabber>(cam, mask),
-        ifm3d::error_t);
+                   ifm3d::error_t);
     }
   else if (cam->IsO3D())
     {
@@ -381,7 +379,7 @@ TEST(FrameGrabber, JSON_model)
       EXPECT_TRUE(fg->WaitForFrame(buff.get(), 1000));
       std::string model = "";
       EXPECT_NO_THROW(model = buff->JSONModel());
-      // checking is its a valid model 
+      // checking is its a valid model
       EXPECT_TRUE(json::parse(model) != NULL);
     }
 }

--- a/modules/image/include/ifm3d/image/image_buffer.h
+++ b/modules/image/include/ifm3d/image/image_buffer.h
@@ -108,14 +108,15 @@ namespace ifm3d
      * Hook called by the base class to populate the image containers.
      */
     template <typename T>
-    void ImCreate(ifm3d::image_chunk im,
-                  std::uint32_t fmt,
-                  std::size_t idx,
-                  std::uint32_t width,
-                  std::uint32_t height,
-                  int nchan,
-                  std::uint32_t npts,
-                  const std::vector<std::uint8_t>& bytes)
+    void
+    ImCreate(ifm3d::image_chunk im,
+             std::uint32_t fmt,
+             std::size_t idx,
+             std::uint32_t width,
+             std::uint32_t height,
+             int nchan,
+             std::uint32_t npts,
+             const std::vector<std::uint8_t>& bytes)
     {
       // NOTE: we drop the template parameter here (and re-establish it later)
       // so that we can maintain our pimpl abstraction in support of the
@@ -129,19 +130,20 @@ namespace ifm3d
      * Hook called by the base class to populate the point cloud containers.
      */
     template <typename T>
-    void CloudCreate(std::uint32_t fmt,
-                     std::size_t xidx,
-                     std::size_t yidx,
-                     std::size_t zidx,
-                     std::uint32_t width,
-                     std::uint32_t height,
-                     std::uint32_t npts,
-                     const std::vector<std::uint8_t>& bytes)
-  {
-    // See "NOTE" in `ImCreate` as to why we are dropping the template
-    // parameter here. Same rationale applies.
-    this->_CloudCreate(fmt, xidx, yidx, zidx, width, height, npts, bytes);
-  }
+    void
+    CloudCreate(std::uint32_t fmt,
+                std::size_t xidx,
+                std::size_t yidx,
+                std::size_t zidx,
+                std::uint32_t width,
+                std::uint32_t height,
+                std::uint32_t npts,
+                const std::vector<std::uint8_t>& bytes)
+    {
+      // See "NOTE" in `ImCreate` as to why we are dropping the template
+      // parameter here. Same rationale applies.
+      this->_CloudCreate(fmt, xidx, yidx, zidx, width, height, npts, bytes);
+    }
 
   private:
     class Impl;

--- a/modules/image/include/ifm3d/image/image_export.h
+++ b/modules/image/include/ifm3d/image/image_export.h
@@ -7,7 +7,7 @@
 #  ifdef IFM3D_IMAGE_DLL_BUILD
 #    define IFM3D_IMAGE_EXPORT __declspec(dllexport)
 #  else
-#     define IFM3D_IMAGE_EXPORT __declspec(dllimport)
+#    define IFM3D_IMAGE_EXPORT __declspec(dllimport)
 #  endif
 #endif
 

--- a/modules/image/src/libifm3d_image/image_buffer.cpp
+++ b/modules/image/src/libifm3d_image/image_buffer.cpp
@@ -42,7 +42,7 @@ ifm3d::ImageBuffer::ImageBuffer(ifm3d::ImageBuffer&& src_buff)
 
 // move assignment
 ifm3d::ImageBuffer&
-ifm3d::ImageBuffer::operator= (ifm3d::ImageBuffer&& src_buff)
+ifm3d::ImageBuffer::operator=(ifm3d::ImageBuffer&& src_buff)
 {
   this->SetBytes(src_buff.bytes_, false);
   return *this;
@@ -58,7 +58,7 @@ ifm3d::ImageBuffer::ImageBuffer(const ifm3d::ImageBuffer& src_buff)
 
 // copy assignment operator
 ifm3d::ImageBuffer&
-ifm3d::ImageBuffer::operator= (const ifm3d::ImageBuffer& src_buff)
+ifm3d::ImageBuffer::operator=(const ifm3d::ImageBuffer& src_buff)
 {
   if (this == &src_buff)
     {

--- a/modules/image/src/libifm3d_image/image_buffer_impl.hpp
+++ b/modules/image/src/libifm3d_image/image_buffer_impl.hpp
@@ -35,8 +35,7 @@
 
 namespace ifm3d
 {
-  std::unordered_map<std::uint32_t, int> PIX_LUT
-  {
+  std::unordered_map<std::uint32_t, int> PIX_LUT{
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8U), CV_8U},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8S), CV_8S},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_16U), CV_16U},
@@ -44,11 +43,9 @@ namespace ifm3d
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32S), CV_32S},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F), CV_32F},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F3), CV_32F},
-    {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_64F), CV_64F}
-  };
+    {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_64F), CV_64F}};
 
-  std::unordered_map<std::uint32_t, int> PIX_LUT3
-  {
+  std::unordered_map<std::uint32_t, int> PIX_LUT3{
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8U), CV_8UC3},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8S), CV_8SC3},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_16U), CV_16UC3},
@@ -56,19 +53,15 @@ namespace ifm3d
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32S), CV_32SC3},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F), CV_32FC3},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F3), CV_32FC3},
-    {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_64F), CV_64FC3}
-  };
+    {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_64F), CV_64FC3}};
 
-  std::unordered_map<int, std::size_t> PIX_SZ
-  {
-    {CV_8U, 1},
-    {CV_8S, 1},
-    {CV_16U, 2},
-    {CV_16S, 2},
-    {CV_32S, 4},
-    {CV_32F, 4},
-    {CV_64F, 8}
-  };
+  std::unordered_map<int, std::size_t> PIX_SZ{{CV_8U, 1},
+                                              {CV_8S, 1},
+                                              {CV_16U, 2},
+                                              {CV_16S, 2},
+                                              {CV_32S, 4},
+                                              {CV_32F, 4},
+                                              {CV_64F, 8}};
 
   //============================================================
   // Impl interface
@@ -117,11 +110,17 @@ namespace ifm3d
     cv::Mat xyz_;
     cv::Mat_<std::uint8_t> bad_; // mask of bad pixels
 
-    template<typename T>
-    void _ImCreate(cv::Mat& im, ifm3d::image_chunk chunk,
-                   std::uint32_t fmt, std::size_t idx,
-                   std::uint32_t width, std::uint32_t height, int nchan,
-                   std::uint32_t npts, const std::vector<std::uint8_t>& bytes)
+    template <typename T>
+    void
+    _ImCreate(cv::Mat& im,
+              ifm3d::image_chunk chunk,
+              std::uint32_t fmt,
+              std::size_t idx,
+              std::uint32_t width,
+              std::uint32_t height,
+              int nchan,
+              std::uint32_t npts,
+              const std::vector<std::uint8_t>& bytes)
     {
       std::size_t incr = sizeof(T) * nchan;
       if (nchan == 3)
@@ -152,13 +151,14 @@ namespace ifm3d
 
           if (nchan == 3)
             {
-              ptr[col3] = ifm3d::mkval<T>(bytes.data()+idx);
-              ptr[col3 + 1] = ifm3d::mkval<T>(bytes.data()+idx+sizeof(T));
-              ptr[col3 + 2] = ifm3d::mkval<T>(bytes.data()+idx+(sizeof(T)*2));
+              ptr[col3] = ifm3d::mkval<T>(bytes.data() + idx);
+              ptr[col3 + 1] = ifm3d::mkval<T>(bytes.data() + idx + sizeof(T));
+              ptr[col3 + 2] =
+                ifm3d::mkval<T>(bytes.data() + idx + (sizeof(T) * 2));
             }
           else
             {
-              ptr[col] = ifm3d::mkval<T>(bytes.data()+idx);
+              ptr[col] = ifm3d::mkval<T>(bytes.data() + idx);
             }
         }
 
@@ -183,14 +183,18 @@ namespace ifm3d
         }
     }
 
-    template<typename T>
-    void _CloudCreate(cv::Mat& im,
-                      pcl::PointCloud<pcl::PointXYZI>::Ptr cloud,
-                      std::uint32_t fmt,
-                      std::size_t xidx, std::size_t yidx, std::size_t zidx,
-                      std::uint32_t width, std::uint32_t height,
-                      std::uint32_t npts,
-                      const std::vector<std::uint8_t>& bytes)
+    template <typename T>
+    void
+    _CloudCreate(cv::Mat& im,
+                 pcl::PointCloud<pcl::PointXYZI>::Ptr cloud,
+                 std::uint32_t fmt,
+                 std::size_t xidx,
+                 std::size_t yidx,
+                 std::size_t zidx,
+                 std::uint32_t width,
+                 std::uint32_t height,
+                 std::uint32_t npts,
+                 const std::vector<std::uint8_t>& bytes)
     {
       std::size_t incr = sizeof(T);
       im.create(height, width, ifm3d::PIX_LUT3.at(fmt));
@@ -238,9 +242,9 @@ namespace ifm3d
             }
 
           // convert to ifm3d coord frame
-          x_ = ifm3d::mkval<T>(bytes.data()+zidx);
-          y_ = -ifm3d::mkval<T>(bytes.data()+xidx);
-          z_ = -ifm3d::mkval<T>(bytes.data()+yidx);
+          x_ = ifm3d::mkval<T>(bytes.data() + zidx);
+          y_ = -ifm3d::mkval<T>(bytes.data() + xidx);
+          z_ = -ifm3d::mkval<T>(bytes.data() + yidx);
 
           if (bad_ptr[col] == 0)
             {
@@ -291,17 +295,17 @@ namespace ifm3d
         }
     }
 
-    template<typename T>
-    void _SetCloudIntensity(pcl::PointCloud<pcl::PointXYZI>::Ptr cloud,
-                            const cv::Mat& im)
+    template <typename T>
+    void
+    _SetCloudIntensity(pcl::PointCloud<pcl::PointXYZI>::Ptr cloud,
+                       const cv::Mat& im)
     {
       int numpts = im.rows * im.cols;
       if (cloud->points.size() != numpts)
         {
           VLOG(IFM3D_PROTO_DEBUG)
             << "Shape mismatch when coloring pcl intensity: "
-            << cloud->points.size() << " vs "
-            << numpts;
+            << cloud->points.size() << " vs " << numpts;
           return;
         }
 
@@ -405,7 +409,7 @@ ifm3d::ImageBuffer::Impl::ImCreate(ifm3d::image_chunk im,
                                    std::uint32_t npts,
                                    const std::vector<std::uint8_t>& bytes)
 {
-  cv::Mat *image;
+  cv::Mat* image;
   switch (im)
     {
     case ifm3d::image_chunk::CONFIDENCE:
@@ -439,43 +443,99 @@ ifm3d::ImageBuffer::Impl::ImCreate(ifm3d::image_chunk im,
   switch (fmt)
     {
     case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8U):
-      this->_ImCreate<std::uint8_t>(
-        *image, im, fmt, idx, width, height, 1, npts, bytes);
+      this->_ImCreate<std::uint8_t>(*image,
+                                    im,
+                                    fmt,
+                                    idx,
+                                    width,
+                                    height,
+                                    1,
+                                    npts,
+                                    bytes);
       break;
 
     case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8S):
-      this->_ImCreate<std::int8_t>(
-        *image, im, fmt, idx, width, height, 1, npts, bytes);
+      this->_ImCreate<std::int8_t>(*image,
+                                   im,
+                                   fmt,
+                                   idx,
+                                   width,
+                                   height,
+                                   1,
+                                   npts,
+                                   bytes);
       break;
 
     case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_16U):
-      this->_ImCreate<std::uint16_t>(
-        *image, im, fmt, idx, width, height, 1, npts, bytes);
+      this->_ImCreate<std::uint16_t>(*image,
+                                     im,
+                                     fmt,
+                                     idx,
+                                     width,
+                                     height,
+                                     1,
+                                     npts,
+                                     bytes);
       break;
 
     case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_16S):
-      this->_ImCreate<std::int16_t>(
-        *image, im, fmt, idx, width, height, 1, npts, bytes);
+      this->_ImCreate<std::int16_t>(*image,
+                                    im,
+                                    fmt,
+                                    idx,
+                                    width,
+                                    height,
+                                    1,
+                                    npts,
+                                    bytes);
       break;
 
     case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32S):
-      this->_ImCreate<std::int32_t>(
-        *image, im, fmt, idx, width, height, 1, npts, bytes);
+      this->_ImCreate<std::int32_t>(*image,
+                                    im,
+                                    fmt,
+                                    idx,
+                                    width,
+                                    height,
+                                    1,
+                                    npts,
+                                    bytes);
       break;
 
     case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F):
-      this->_ImCreate<float>(
-        *image, im, fmt, idx, width, height, 1, npts, bytes);
+      this->_ImCreate<float>(*image,
+                             im,
+                             fmt,
+                             idx,
+                             width,
+                             height,
+                             1,
+                             npts,
+                             bytes);
       break;
 
     case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F3):
-      this->_ImCreate<float>(
-        *image, im, fmt, idx, width, height, 3, npts, bytes);
+      this->_ImCreate<float>(*image,
+                             im,
+                             fmt,
+                             idx,
+                             width,
+                             height,
+                             3,
+                             npts,
+                             bytes);
       break;
 
     case static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_64F):
-      this->_ImCreate<double>(
-        *image, im, fmt, idx, width, height, 1, npts, bytes);
+      this->_ImCreate<double>(*image,
+                              im,
+                              fmt,
+                              idx,
+                              width,
+                              height,
+                              1,
+                              npts,
+                              bytes);
       break;
 
     default:
@@ -545,8 +605,7 @@ ifm3d::ImageBuffer::Impl::CloudCreate(std::uint32_t fmt,
       break;
 
     case CV_16U:
-      this->_SetCloudIntensity<std::uint16_t>(this->cloud_,
-                                               this->amp_);
+      this->_SetCloudIntensity<std::uint16_t>(this->cloud_, this->amp_);
       break;
 
     case CV_16S:

--- a/modules/image/test/ifm3d-image-testrunner.cpp
+++ b/modules/image/test/ifm3d-image-testrunner.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
-int main(int argc, char **argv)
+int
+main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/modules/image/test/ifm3d-image-tests.cpp
+++ b/modules/image/test/ifm3d-image-tests.cpp
@@ -12,11 +12,12 @@
 #include <gtest/gtest.h>
 
 template <typename T>
-bool cmp_with_nan(T a, T b)
+bool
+cmp_with_nan(T a, T b)
 {
   if (std::isnan(a) || std::isnan(b))
     {
-      return(std::isnan(a) && std::isnan(b));
+      return (std::isnan(a) && std::isnan(b));
     }
   else
     {
@@ -45,7 +46,8 @@ TEST(Image, MoveCtor)
       EXPECT_TRUE(amp2.type() == CV_32F);
       EXPECT_TRUE(std::equal(copy_of_amp.begin<float>(),
                              copy_of_amp.end<float>(),
-                             amp2.begin<float>(), cmp_with_nan<float>));
+                             amp2.begin<float>(),
+                             cmp_with_nan<float>));
     }
   else
     {
@@ -80,7 +82,8 @@ TEST(Image, MoveAssignmentOperator)
       EXPECT_TRUE(amp2.type() == CV_32F);
       EXPECT_TRUE(std::equal(copy_of_amp.begin<float>(),
                              copy_of_amp.end<float>(),
-                             amp2.begin<float>(), cmp_with_nan<float>));
+                             amp2.begin<float>(),
+                             cmp_with_nan<float>));
     }
   else
     {
@@ -115,8 +118,10 @@ TEST(Image, CopyCtor)
     {
       EXPECT_TRUE(amp.type() == CV_32F);
       EXPECT_TRUE(amp2.type() == CV_32F);
-      EXPECT_TRUE(std::equal(amp.begin<float>(), amp.end<float>(),
-                             amp2.begin<float>(), cmp_with_nan<float>));
+      EXPECT_TRUE(std::equal(amp.begin<float>(),
+                             amp.end<float>(),
+                             amp2.begin<float>(),
+                             cmp_with_nan<float>));
     }
   else
     {
@@ -133,7 +138,8 @@ TEST(Image, CopyCtor)
     {
       EXPECT_FALSE(std::equal(amp.begin<float>(),
                               amp.end<float>(),
-                              amp2.begin<float>(), cmp_with_nan<float>));
+                              amp2.begin<float>(),
+                              cmp_with_nan<float>));
     }
   else
     {
@@ -165,7 +171,8 @@ TEST(Image, CopyAssignmentOperator)
       EXPECT_TRUE(amp2.type() == CV_32F);
       EXPECT_TRUE(std::equal(amp.begin<float>(),
                              amp.end<float>(),
-                             amp2.begin<float>(), cmp_with_nan<float>));
+                             amp2.begin<float>(),
+                             cmp_with_nan<float>));
     }
   else
     {
@@ -182,7 +189,8 @@ TEST(Image, CopyAssignmentOperator)
     {
       EXPECT_FALSE(std::equal(amp.begin<float>(),
                               amp.end<float>(),
-                              amp2.begin<float>(), cmp_with_nan<float>));
+                              amp2.begin<float>(),
+                              cmp_with_nan<float>));
     }
   else
     {
@@ -211,7 +219,8 @@ TEST(Image, References)
       EXPECT_TRUE(amp2.type() == CV_32F);
       EXPECT_TRUE(std::equal(amp1.begin<float>(),
                              amp1.end<float>(),
-                             amp2.begin<float>(), cmp_with_nan<float>));
+                             amp2.begin<float>(),
+                             cmp_with_nan<float>));
     }
   else
     {
@@ -228,7 +237,8 @@ TEST(Image, References)
     {
       EXPECT_TRUE(std::equal(amp1.begin<float>(),
                              amp1.end<float>(),
-                             amp2.begin<float>(), cmp_with_nan<float>));
+                             amp2.begin<float>(),
+                             cmp_with_nan<float>));
     }
   else
     {
@@ -304,22 +314,22 @@ TEST(Image, XYZImage)
           ifm3d::PointT& pt = cloud->points[i];
           if (xyz.type() == CV_16SC3)
             {
-              EXPECT_FLOAT_EQ(pt.x * 1000., (float) x.at<std::int16_t>(r,c));
-              EXPECT_FLOAT_EQ(pt.y * 1000., (float) y.at<std::int16_t>(r,c));
-              EXPECT_FLOAT_EQ(pt.z * 1000., (float) z.at<std::int16_t>(r,c));
+              EXPECT_FLOAT_EQ(pt.x * 1000., (float)x.at<std::int16_t>(r, c));
+              EXPECT_FLOAT_EQ(pt.y * 1000., (float)y.at<std::int16_t>(r, c));
+              EXPECT_FLOAT_EQ(pt.z * 1000., (float)z.at<std::int16_t>(r, c));
             }
           else
             {
-              if (std::isnan(pt.x) || std::isnan(x.at<float>(r,c)))
+              if (std::isnan(pt.x) || std::isnan(x.at<float>(r, c)))
                 {
                   EXPECT_TRUE(std::isnan(pt.x));
-                  EXPECT_TRUE(std::isnan(x.at<float>(r,c)));
+                  EXPECT_TRUE(std::isnan(x.at<float>(r, c)));
                 }
               else
                 {
-                  EXPECT_FLOAT_EQ(pt.x, x.at<float>(r,c));
-                  EXPECT_FLOAT_EQ(pt.y, y.at<float>(r,c));
-                  EXPECT_FLOAT_EQ(pt.z, z.at<float>(r,c));
+                  EXPECT_FLOAT_EQ(pt.x, x.at<float>(r, c));
+                  EXPECT_FLOAT_EQ(pt.y, y.at<float>(r, c));
+                  EXPECT_FLOAT_EQ(pt.z, z.at<float>(r, c));
                 }
             }
         }
@@ -351,8 +361,9 @@ TEST(Image, ComputeCartesian)
   // data. The latter we simply use as ground truth
   //
   fg.reset();
-  fg = std::make_shared<ifm3d::FrameGrabber>(
-         cam, ifm3d::IMG_RDIS|ifm3d::IMG_CART);
+  fg =
+    std::make_shared<ifm3d::FrameGrabber>(cam,
+                                          ifm3d::IMG_RDIS | ifm3d::IMG_CART);
   EXPECT_TRUE(fg->WaitForFrame(im.get(), 1000));
   cv::Mat rdis = im->DistanceImage();
   cv::Mat conf = im->ConfidenceImage();
@@ -439,27 +450,29 @@ TEST(Image, ComputeCartesian)
   //
   // 5. Compare for correctness
   //
-  auto cmp = [](std::int16_t a, std::int16_t b) -> bool
-    {
-      if (std::abs(a - b) <= 10) // 10 mm == cm accuracy
-        {
-          return true;
-        }
+  auto cmp = [](std::int16_t a, std::int16_t b) -> bool {
+    if (std::abs(a - b) <= 10) // 10 mm == cm accuracy
+      {
+        return true;
+      }
 
-      return false;
-    };
+    return false;
+  };
 
   EXPECT_TRUE(std::equal(x_cam.begin<std::int16_t>(),
                          x_cam.end<std::int16_t>(),
-                         x_computed.begin<std::int16_t>(), cmp));
+                         x_computed.begin<std::int16_t>(),
+                         cmp));
 
   EXPECT_TRUE(std::equal(y_cam.begin<std::int16_t>(),
                          y_cam.end<std::int16_t>(),
-                         y_computed.begin<std::int16_t>(), cmp));
+                         y_computed.begin<std::int16_t>(),
+                         cmp));
 
   EXPECT_TRUE(std::equal(z_cam.begin<std::int16_t>(),
                          z_cam.end<std::int16_t>(),
-                         z_computed.begin<std::int16_t>(), cmp));
+                         z_computed.begin<std::int16_t>(),
+                         cmp));
 }
 
 TEST(Image, TimeStamp)
@@ -496,21 +509,22 @@ TEST(Image, TimeStamp)
 
   ifm3d::ImageBuffer::Ptr img = std::make_shared<ifm3d::ImageBuffer>();
   ifm3d::FrameGrabber::Ptr fg =
-    std::make_shared<ifm3d::FrameGrabber>(
-      cam, ifm3d::IMG_AMP|ifm3d::IMG_CART);
+    std::make_shared<ifm3d::FrameGrabber>(cam,
+                                          ifm3d::IMG_AMP | ifm3d::IMG_CART);
 
   std::array<ifm3d::TimePointT, 2> tps;
   // get two consecutive timestamps
   for (ifm3d::TimePointT& t : tps)
-  {
+    {
       EXPECT_TRUE(fg->WaitForFrame(img.get(), 1000));
       t = img->TimeStamp();
-  }
+    }
   // the first time point need to be smaller than the second one
-  EXPECT_LT(tps[0],tps[1]);
-  auto tdiff = std::chrono::duration_cast<std::chrono::milliseconds>(
-                 tps[1] - tps[0]).count();
-  EXPECT_GT(tdiff,20);
+  EXPECT_LT(tps[0], tps[1]);
+  auto tdiff =
+    std::chrono::duration_cast<std::chrono::milliseconds>(tps[1] - tps[0])
+      .count();
+  EXPECT_GT(tdiff, 20);
 }
 
 TEST(Image, IlluTemp)
@@ -518,9 +532,9 @@ TEST(Image, IlluTemp)
   ifm3d::Camera::Ptr cam = std::make_shared<ifm3d::Camera>();
 
   ifm3d::ImageBuffer::Ptr img = std::make_shared<ifm3d::ImageBuffer>();
-  ifm3d::FrameGrabber::Ptr fg =
-    std::make_shared<ifm3d::FrameGrabber>(
-      cam, ifm3d::DEFAULT_SCHEMA_MASK | ifm3d::ILLU_TEMP);
+  ifm3d::FrameGrabber::Ptr fg = std::make_shared<ifm3d::FrameGrabber>(
+    cam,
+    ifm3d::DEFAULT_SCHEMA_MASK | ifm3d::ILLU_TEMP);
 
   ASSERT_TRUE(fg->WaitForFrame(img.get(), 1000));
 

--- a/modules/opencv/include/ifm3d/opencv/detail/opencv_buffer.hpp
+++ b/modules/opencv/include/ifm3d/opencv/detail/opencv_buffer.hpp
@@ -33,8 +33,7 @@ namespace ifm3d
   // installed.
   //
 
-  static std::unordered_map<std::uint32_t, int> PIX_LUT_
-  {
+  static std::unordered_map<std::uint32_t, int> PIX_LUT_{
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8U), CV_8U},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8S), CV_8S},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_16U), CV_16U},
@@ -42,11 +41,9 @@ namespace ifm3d
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32S), CV_32S},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F), CV_32F},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F3), CV_32F},
-    {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_64F), CV_64F}
-  };
+    {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_64F), CV_64F}};
 
-  static std::unordered_map<std::uint32_t, int> PIX_LUT3_
-  {
+  static std::unordered_map<std::uint32_t, int> PIX_LUT3_{
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8U), CV_8UC3},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_8S), CV_8SC3},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_16U), CV_16UC3},
@@ -54,8 +51,7 @@ namespace ifm3d
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32S), CV_32SC3},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F), CV_32FC3},
     {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_32F3), CV_32FC3},
-    {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_64F), CV_64FC3}
-  };
+    {static_cast<std::uint32_t>(ifm3d::pixel_format::FORMAT_64F), CV_64FC3}};
 
 } // end: namespace ifm3d
 
@@ -78,7 +74,7 @@ inline ifm3d::OpenCVBuffer::OpenCVBuffer(ifm3d::OpenCVBuffer&& src_buff)
 
 // move assignment
 inline ifm3d::OpenCVBuffer&
-ifm3d::OpenCVBuffer::operator= (ifm3d::OpenCVBuffer&& src_buff)
+ifm3d::OpenCVBuffer::operator=(ifm3d::OpenCVBuffer&& src_buff)
 {
   this->SetBytes(src_buff.bytes_, false);
   return *this;
@@ -94,7 +90,7 @@ inline ifm3d::OpenCVBuffer::OpenCVBuffer(const ifm3d::OpenCVBuffer& src_buff)
 
 // copy assignment
 inline ifm3d::OpenCVBuffer&
-ifm3d::OpenCVBuffer::operator= (const ifm3d::OpenCVBuffer& src_buff)
+ifm3d::OpenCVBuffer::operator=(const ifm3d::OpenCVBuffer& src_buff)
 {
   if (this == &src_buff)
     {
@@ -166,7 +162,7 @@ ifm3d::OpenCVBuffer::ImCreate(ifm3d::image_chunk im,
                               std::uint32_t npts,
                               const std::vector<std::uint8_t>& bytes)
 {
-  cv::Mat *mat;
+  cv::Mat* mat;
   switch (im)
     {
     case ifm3d::image_chunk::CONFIDENCE:
@@ -226,13 +222,14 @@ ifm3d::OpenCVBuffer::ImCreate(ifm3d::image_chunk im,
 
       if (nchan == 3)
         {
-          ptr[col3] = ifm3d::mkval<T>(bytes.data()+idx);
-          ptr[col3 + 1] = ifm3d::mkval<T>(bytes.data()+idx+sizeof(T));
-          ptr[col3 + 2] = ifm3d::mkval<T>(bytes.data()+idx+(sizeof(T)*2));
+          ptr[col3] = ifm3d::mkval<T>(bytes.data() + idx);
+          ptr[col3 + 1] = ifm3d::mkval<T>(bytes.data() + idx + sizeof(T));
+          ptr[col3 + 2] =
+            ifm3d::mkval<T>(bytes.data() + idx + (sizeof(T) * 2));
         }
       else
         {
-          ptr[col] = ifm3d::mkval<T>(bytes.data()+idx);
+          ptr[col] = ifm3d::mkval<T>(bytes.data() + idx);
         }
     }
 
@@ -291,9 +288,9 @@ ifm3d::OpenCVBuffer::CloudCreate(std::uint32_t fmt,
         }
 
       // convert to ifm3d coord frame
-      x_ = ifm3d::mkval<T>(bytes.data()+zidx);
-      y_ = -ifm3d::mkval<T>(bytes.data()+xidx);
-      z_ = -ifm3d::mkval<T>(bytes.data()+yidx);
+      x_ = ifm3d::mkval<T>(bytes.data() + zidx);
+      y_ = -ifm3d::mkval<T>(bytes.data() + xidx);
+      z_ = -ifm3d::mkval<T>(bytes.data() + yidx);
 
       if (bad_ptr[col] == 0)
         {

--- a/modules/opencv/test/ifm3d-opencv-testrunner.cpp
+++ b/modules/opencv/test/ifm3d-opencv-testrunner.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
-int main(int argc, char **argv)
+int
+main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/modules/opencv/test/ifm3d-opencv-tests.cpp
+++ b/modules/opencv/test/ifm3d-opencv-tests.cpp
@@ -11,11 +11,12 @@
 #include <gtest/gtest.h>
 
 template <typename T>
-bool cmp_with_nan(T a, T b)
+bool
+cmp_with_nan(T a, T b)
 {
   if (std::isnan(a) || std::isnan(b))
     {
-      return(std::isnan(a) && std::isnan(b));
+      return (std::isnan(a) && std::isnan(b));
     }
   else
     {
@@ -44,7 +45,8 @@ TEST(OpenCV, MoveCtor)
       EXPECT_TRUE(amp2.type() == CV_32F);
       EXPECT_TRUE(std::equal(copy_of_amp.begin<float>(),
                              copy_of_amp.end<float>(),
-                             amp2.begin<float>(), cmp_with_nan<float>));
+                             amp2.begin<float>(),
+                             cmp_with_nan<float>));
     }
   else
     {
@@ -79,7 +81,8 @@ TEST(OpenCV, MoveAssignmentOperator)
       EXPECT_TRUE(amp2.type() == CV_32F);
       EXPECT_TRUE(std::equal(copy_of_amp.begin<float>(),
                              copy_of_amp.end<float>(),
-                             amp2.begin<float>(), cmp_with_nan<float>));
+                             amp2.begin<float>(),
+                             cmp_with_nan<float>));
     }
   else
     {
@@ -114,8 +117,10 @@ TEST(OpenCV, CopyCtor)
     {
       EXPECT_TRUE(amp.type() == CV_32F);
       EXPECT_TRUE(amp2.type() == CV_32F);
-      EXPECT_TRUE(std::equal(amp.begin<float>(), amp.end<float>(),
-                             amp2.begin<float>(), cmp_with_nan<float>));
+      EXPECT_TRUE(std::equal(amp.begin<float>(),
+                             amp.end<float>(),
+                             amp2.begin<float>(),
+                             cmp_with_nan<float>));
     }
   else
     {
@@ -132,7 +137,8 @@ TEST(OpenCV, CopyCtor)
     {
       EXPECT_FALSE(std::equal(amp.begin<float>(),
                               amp.end<float>(),
-                              amp2.begin<float>(), cmp_with_nan<float>));
+                              amp2.begin<float>(),
+                              cmp_with_nan<float>));
     }
   else
     {
@@ -164,7 +170,8 @@ TEST(OpenCV, CopyAssignmentOperator)
       EXPECT_TRUE(amp2.type() == CV_32F);
       EXPECT_TRUE(std::equal(amp.begin<float>(),
                              amp.end<float>(),
-                             amp2.begin<float>(), cmp_with_nan<float>));
+                             amp2.begin<float>(),
+                             cmp_with_nan<float>));
     }
   else
     {
@@ -181,7 +188,8 @@ TEST(OpenCV, CopyAssignmentOperator)
     {
       EXPECT_FALSE(std::equal(amp.begin<float>(),
                               amp.end<float>(),
-                              amp2.begin<float>(), cmp_with_nan<float>));
+                              amp2.begin<float>(),
+                              cmp_with_nan<float>));
     }
   else
     {
@@ -210,7 +218,8 @@ TEST(OpenCV, References)
       EXPECT_TRUE(amp2.type() == CV_32F);
       EXPECT_TRUE(std::equal(amp1.begin<float>(),
                              amp1.end<float>(),
-                             amp2.begin<float>(), cmp_with_nan<float>));
+                             amp2.begin<float>(),
+                             cmp_with_nan<float>));
     }
   else
     {
@@ -227,7 +236,8 @@ TEST(OpenCV, References)
     {
       EXPECT_TRUE(std::equal(amp1.begin<float>(),
                              amp1.end<float>(),
-                             amp2.begin<float>(), cmp_with_nan<float>));
+                             amp2.begin<float>(),
+                             cmp_with_nan<float>));
     }
   else
     {
@@ -262,8 +272,9 @@ TEST(OpenCV, ComputeCartesian)
   // data. The latter we simply use as ground truth
   //
   fg.reset();
-  fg = std::make_shared<ifm3d::FrameGrabber>(
-         cam, ifm3d::IMG_RDIS|ifm3d::IMG_CART);
+  fg =
+    std::make_shared<ifm3d::FrameGrabber>(cam,
+                                          ifm3d::IMG_RDIS | ifm3d::IMG_CART);
   EXPECT_TRUE(fg->WaitForFrame(im.get(), 1000));
   cv::Mat rdis = im->DistanceImage();
   cv::Mat conf = im->ConfidenceImage();
@@ -350,27 +361,29 @@ TEST(OpenCV, ComputeCartesian)
   //
   // 5. Compare for correctness
   //
-  auto cmp = [](std::int16_t a, std::int16_t b) -> bool
-    {
-      if (std::abs(a - b) <= 10) // 10 mm == cm accuracy
-        {
-          return true;
-        }
+  auto cmp = [](std::int16_t a, std::int16_t b) -> bool {
+    if (std::abs(a - b) <= 10) // 10 mm == cm accuracy
+      {
+        return true;
+      }
 
-      return false;
-    };
+    return false;
+  };
 
   EXPECT_TRUE(std::equal(x_cam.begin<std::int16_t>(),
                          x_cam.end<std::int16_t>(),
-                         x_computed.begin<std::int16_t>(), cmp));
+                         x_computed.begin<std::int16_t>(),
+                         cmp));
 
   EXPECT_TRUE(std::equal(y_cam.begin<std::int16_t>(),
                          y_cam.end<std::int16_t>(),
-                         y_computed.begin<std::int16_t>(), cmp));
+                         y_computed.begin<std::int16_t>(),
+                         cmp));
 
   EXPECT_TRUE(std::equal(z_cam.begin<std::int16_t>(),
                          z_cam.end<std::int16_t>(),
-                         z_computed.begin<std::int16_t>(), cmp));
+                         z_computed.begin<std::int16_t>(),
+                         cmp));
 }
 
 TEST(OpenCV, TimeStamp)
@@ -407,21 +420,22 @@ TEST(OpenCV, TimeStamp)
 
   ifm3d::OpenCVBuffer::Ptr img = std::make_shared<ifm3d::OpenCVBuffer>();
   ifm3d::FrameGrabber::Ptr fg =
-    std::make_shared<ifm3d::FrameGrabber>(
-      cam, ifm3d::IMG_AMP|ifm3d::IMG_CART);
+    std::make_shared<ifm3d::FrameGrabber>(cam,
+                                          ifm3d::IMG_AMP | ifm3d::IMG_CART);
 
   std::array<ifm3d::TimePointT, 2> tps;
   // get two consecutive timestamps
   for (ifm3d::TimePointT& t : tps)
-  {
+    {
       EXPECT_TRUE(fg->WaitForFrame(img.get(), 1000));
       t = img->TimeStamp();
-  }
+    }
   // the first time point need to be smaller than the second one
-  EXPECT_LT(tps[0],tps[1]);
-  auto tdiff = std::chrono::duration_cast<std::chrono::milliseconds>(
-                 tps[1] - tps[0]).count();
-  EXPECT_GT(tdiff,20);
+  EXPECT_LT(tps[0], tps[1]);
+  auto tdiff =
+    std::chrono::duration_cast<std::chrono::milliseconds>(tps[1] - tps[0])
+      .count();
+  EXPECT_GT(tdiff, 20);
 }
 
 TEST(OpenCV, IlluTemp)
@@ -429,9 +443,9 @@ TEST(OpenCV, IlluTemp)
   ifm3d::Camera::Ptr cam = std::make_shared<ifm3d::Camera>();
 
   ifm3d::OpenCVBuffer::Ptr img = std::make_shared<ifm3d::OpenCVBuffer>();
-  ifm3d::FrameGrabber::Ptr fg =
-    std::make_shared<ifm3d::FrameGrabber>(
-      cam, ifm3d::DEFAULT_SCHEMA_MASK | ifm3d::ILLU_TEMP);
+  ifm3d::FrameGrabber::Ptr fg = std::make_shared<ifm3d::FrameGrabber>(
+    cam,
+    ifm3d::DEFAULT_SCHEMA_MASK | ifm3d::ILLU_TEMP);
 
   ASSERT_TRUE(fg->WaitForFrame(img.get(), 1000));
 

--- a/modules/pcicclient/include/ifm3d/pcicclient/pcicclient.h
+++ b/modules/pcicclient/include/ifm3d/pcicclient/pcicclient.h
@@ -102,7 +102,8 @@ namespace ifm3d
      * @return Copy of received plain response data as string
      * (without any header information, like ticket, length, etc.)
      *
-     * NOTE: This Call can block and hang indefinitely depending upon PCIC response.
+     * NOTE: This Call can block and hang indefinitely depending upon PCIC
+     * response.
      */
     std::string Call(const std::string& request);
 
@@ -129,7 +130,9 @@ namespace ifm3d
      *
      * @return true if Call succeeded, false if failed.
      */
-    bool Call(const std::string& request, std::string &response, long timeout_millis);
+    bool Call(const std::string& request,
+              std::string& response,
+              long timeout_millis);
 
     /**
      * Sets the specified callback for receiving asynchronous error messages
@@ -159,7 +162,8 @@ namespace ifm3d
      *            message from camera (without any header information, like
      *            ticket, length, etc.)
      *
-     * @return Callback id, which can be used to cancel receiving notifications.
+     * @return Callback id, which can be used to cancel receiving
+     * notifications.
      */
     long SetNotificationCallback(
       std::function<void(const std::string& notification)> callback);
@@ -168,7 +172,8 @@ namespace ifm3d
      * Cancels registered callbacks. Must be called in case references/pointers
      * provided through callbacks get invalid. If callback id isn't present
      * internally anymore, i.e. if callback was replaced, already canceled or
-     * automatically removed (in case of the Call method), it is simply ignored.
+     * automatically removed (in case of the Call method), it is simply
+     * ignored.
      *
      * @param[in] callback_id Callback id, returned by methods which take a
      *                        callback as parameter.
@@ -178,7 +183,7 @@ namespace ifm3d
   private:
     class Impl;
     std::unique_ptr<Impl> pImpl;
-   
+
   }; // end: class PCICClient
 
 } // end: namespace ifm3d

--- a/modules/pcicclient/include/ifm3d/pcicclient/pcicclient_export.h
+++ b/modules/pcicclient/include/ifm3d/pcicclient/pcicclient_export.h
@@ -7,9 +7,8 @@
 #  ifdef IFM3D_PCICCLIENT_DLL_BUILD
 #    define IFM3D_PCICCLIENT_EXPORT __declspec(dllexport)
 #  else
-#     define IFM3D_PCICCLIENT_EXPORT __declspec(dllimport)
+#    define IFM3D_PCICCLIENT_EXPORT __declspec(dllimport)
 #  endif
 #endif
 
 #endif /* IFM3D_PCICCLIENT_EXPORT_HPP */
-

--- a/modules/pcicclient/src/libifm3d_pcicclient/pcicclient.cpp
+++ b/modules/pcicclient/src/libifm3d_pcicclient/pcicclient.cpp
@@ -24,56 +24,56 @@
 #include <ifm3d/camera/err.h>
 #include <pcicclient_impl.hpp>
 
-
-ifm3d::PCICClient::PCICClient(ifm3d::Camera::Ptr cam): pImpl(new ifm3d::PCICClient::Impl(cam))
-{
-}
+ifm3d::PCICClient::PCICClient(ifm3d::Camera::Ptr cam)
+  : pImpl(new ifm3d::PCICClient::Impl(cam))
+{ }
 
 ifm3d::PCICClient::~PCICClient() = default;
 
 void
 ifm3d::PCICClient::Stop()
 {
-	return this->pImpl->Stop();
+  return this->pImpl->Stop();
 }
 
 long
-ifm3d::PCICClient::Call(const std::string& request,
-			 std::function<void(const std::string& response)> callback)
+ifm3d::PCICClient::Call(
+  const std::string& request,
+  std::function<void(const std::string& response)> callback)
 {
-	return this->pImpl->Call(request, callback);
+  return this->pImpl->Call(request, callback);
 }
 
 std::string
 ifm3d::PCICClient::Call(const std::string& request)
 {
-	return this->pImpl->Call(request);
+  return this->pImpl->Call(request);
 }
 
 bool
 ifm3d::PCICClient::Call(const std::string& request,
-			 std::string& response, long timeout_millis)
+                        std::string& response,
+                        long timeout_millis)
 {
-	return this->pImpl->Call(request, response, timeout_millis);
+  return this->pImpl->Call(request, response, timeout_millis);
 }
 
 long
-ifm3d::PCICClient
-::SetErrorCallback(std::function<void(const std::string& error)> callback)
+ifm3d::PCICClient ::SetErrorCallback(
+  std::function<void(const std::string& error)> callback)
 {
-	return this->pImpl->SetErrorCallback(callback);
+  return this->pImpl->SetErrorCallback(callback);
 }
 
 long
-ifm3d::PCICClient
-::SetNotificationCallback(std::function<void(const std::string& notification)> callback)
+ifm3d::PCICClient ::SetNotificationCallback(
+  std::function<void(const std::string& notification)> callback)
 {
-	return this->pImpl->SetNotificationCallback(callback);
+  return this->pImpl->SetNotificationCallback(callback);
 }
 
 void
 ifm3d::PCICClient::CancelCallback(long callback_id)
 {
-	return this->pImpl->CancelCallback(callback_id);
+  return this->pImpl->CancelCallback(callback_id);
 }
-

--- a/modules/pcicclient/src/libifm3d_pcicclient/pcicclient_impl.hpp
+++ b/modules/pcicclient/src/libifm3d_pcicclient/pcicclient_impl.hpp
@@ -43,12 +43,11 @@
 
 namespace ifm3d
 {
-	const int ONE_TIME_TICKET_LOWER_RANGE  = 1000;
-	const int ONE_TIME_TICKET_HIGHER_RANGE = 9999;
-	const int CONNECTED_FLAG_TIMEOUT = 2000;
-	const int PRE_CONTENT_BUFFER_LENGTH = 20;
-	const int POST_CONTENT_BUFFER_LENGTH = 2;
-
+  const int ONE_TIME_TICKET_LOWER_RANGE = 1000;
+  const int ONE_TIME_TICKET_HIGHER_RANGE = 9999;
+  const int CONNECTED_FLAG_TIMEOUT = 2000;
+  const int PRE_CONTENT_BUFFER_LENGTH = 20;
+  const int POST_CONTENT_BUFFER_LENGTH = 2;
 
   //============================================================
   // Impl interface
@@ -59,200 +58,211 @@ namespace ifm3d
     Impl(ifm3d::Camera::Ptr cam);
     ~Impl();
 
-	/**
-	* Interrupts the running thread by throwing an ifm3d::error_t with code
-	* IFM3D_THREAD_INTERRUPTED.
-	*
-	* While this is (currently) part of the public interface, clients should
-	* be aware that there is really no way to restart a stopped PCICClient
-	* instance. To do that, you would need to instantiate a new PCICClient.
-	*/
-	void Stop();
+    /**
+     * Interrupts the running thread by throwing an ifm3d::error_t with code
+     * IFM3D_THREAD_INTERRUPTED.
+     *
+     * While this is (currently) part of the public interface, clients should
+     * be aware that there is really no way to restart a stopped PCICClient
+     * instance. To do that, you would need to instantiate a new PCICClient.
+     */
+    void Stop();
 
-	/**
-	* Sends a PCIC command to the camera and returns the response
-	* asynchronously through a callback (, which is automatically
-	* removed internally after the callback returns).
-	*
-	* Note: Since the PCICClient is unbuffered, the calling thread
-	* will be blocked while the request is not completely sent. Also,
-	* the receiving thread will be blocked while the response callback
-	* has not returned.
-	*
-	* @param[in] request String containing the plain command
-	* (without any header information, like ticket, length, etc.)
-	*
-	* @param[in] callback Function, called after receiving the response
-	* from the camera, providing the plain response data as string
-	* (without any header information, like ticket, length, etc.)
-	*
-	* @return Callback id, which can be used to cancel this Call before
-	* receiving the response.
-	*/
-	long Call(const std::string& request,
-		std::function<void(const std::string& response)> callback);
+    /**
+     * Sends a PCIC command to the camera and returns the response
+     * asynchronously through a callback (, which is automatically
+     * removed internally after the callback returns).
+     *
+     * Note: Since the PCICClient is unbuffered, the calling thread
+     * will be blocked while the request is not completely sent. Also,
+     * the receiving thread will be blocked while the response callback
+     * has not returned.
+     *
+     * @param[in] request String containing the plain command
+     * (without any header information, like ticket, length, etc.)
+     *
+     * @param[in] callback Function, called after receiving the response
+     * from the camera, providing the plain response data as string
+     * (without any header information, like ticket, length, etc.)
+     *
+     * @return Callback id, which can be used to cancel this Call before
+     * receiving the response.
+     */
+    long Call(const std::string& request,
+              std::function<void(const std::string& response)> callback);
 
-	/**
-	* Sends a PCIC command to the camera and returns the response
-	* as soon as it has been received. In the meanwhile, this call
-	* is blocked.
-	*
-	* @param[in] request String containing the plain command
-	* (without any header infomration, like ticket, length, etc.)
-	*
-	* @return Copy of received plain response data as string
-	* (without any header information, like ticket, length, etc.)
-	*
-	* NOTE: This Call can block and hang indefinitely depending upon PCIC response.
-	*/
-	std::string Call(const std::string& request);
+    /**
+     * Sends a PCIC command to the camera and returns the response
+     * as soon as it has been received. In the meanwhile, this call
+     * is blocked.
+     *
+     * @param[in] request String containing the plain command
+     * (without any header infomration, like ticket, length, etc.)
+     *
+     * @return Copy of received plain response data as string
+     * (without any header information, like ticket, length, etc.)
+     *
+     * NOTE: This Call can block and hang indefinitely depending upon PCIC
+     * response.
+     */
+    std::string Call(const std::string& request);
 
-	/**
-	* Similar to the Call function above.
-	*
-	* Sends a PCIC command to the camera and returns the response
-	* as soon as it has been received. In the meanwhile, this call
-	* is blocked.
-	*
-	* @param[in] request String containing the plain command
-	* (without any header infomration, like ticket, length, etc.)
-	*
-	* @param[in] response String containing the response from the camera
-	*  providing the plain response data as string
-	* (without any header information, like ticket, length, etc.)
-	*
-	* @param[in] timeout in milliseconds, in case, the PCIC fails to come
-	* through.
-	*
-	* NOTE: This Call can fail with no response if supplied with an
-	* unsuitable "timeout_millis" value. Providing timeout_millis value as 0
-	* results in behaviour similar to the above Call method.
-	*
-	* @return true if Call succeeded, false if failed.
-	*/
-	bool Call(const std::string& request, std::string &response, long timeout_millis);
+    /**
+     * Similar to the Call function above.
+     *
+     * Sends a PCIC command to the camera and returns the response
+     * as soon as it has been received. In the meanwhile, this call
+     * is blocked.
+     *
+     * @param[in] request String containing the plain command
+     * (without any header infomration, like ticket, length, etc.)
+     *
+     * @param[in] response String containing the response from the camera
+     *  providing the plain response data as string
+     * (without any header information, like ticket, length, etc.)
+     *
+     * @param[in] timeout in milliseconds, in case, the PCIC fails to come
+     * through.
+     *
+     * NOTE: This Call can fail with no response if supplied with an
+     * unsuitable "timeout_millis" value. Providing timeout_millis value as 0
+     * results in behaviour similar to the above Call method.
+     *
+     * @return true if Call succeeded, false if failed.
+     */
+    bool Call(const std::string& request,
+              std::string& response,
+              long timeout_millis);
 
-	/**
-	* Sets the specified callback for receiving asynchronous error messages
-	* until it is replaced by a new callback or canceled via
-	* @see CancelCallback.
-	*
-	* Note: Since the PCICClient is unbuffered, the receiving thread will be
-	* blocked while the error callback has not returned.
-	*
-	* @param[in] callback Function, called after receiving an error message
-	* from camera (without any header information, like ticket, length, etc.)
-	*
-	* @return Callback id, which can be used to cancel receiving errors.
-	*/
-	long SetErrorCallback(
-		std::function<void(const std::string& error)> callback);
+    /**
+     * Sets the specified callback for receiving asynchronous error messages
+     * until it is replaced by a new callback or canceled via
+     * @see CancelCallback.
+     *
+     * Note: Since the PCICClient is unbuffered, the receiving thread will be
+     * blocked while the error callback has not returned.
+     *
+     * @param[in] callback Function, called after receiving an error message
+     * from camera (without any header information, like ticket, length, etc.)
+     *
+     * @return Callback id, which can be used to cancel receiving errors.
+     */
+    long SetErrorCallback(
+      std::function<void(const std::string& error)> callback);
 
-	/**
-	* Sets the specified callback for receiving asynchronous notification
-	* messages until it is replaced by a new callback or canceled via
-	* @see CancelCallback.
-	*
-	* Note: Since the PCICClient is unbuffered, the receiving thread will be
-	* blocked while the notification callback has not returned.
-	*
-	* @param[in] callback Function, called after receiving an notification
-	*            message from camera (without any header information, like
-	*            ticket, length, etc.)
-	*
-	* @return Callback id, which can be used to cancel receiving notifications.
-	*/
-	long SetNotificationCallback(
-		std::function<void(const std::string& notification)> callback);
+    /**
+     * Sets the specified callback for receiving asynchronous notification
+     * messages until it is replaced by a new callback or canceled via
+     * @see CancelCallback.
+     *
+     * Note: Since the PCICClient is unbuffered, the receiving thread will be
+     * blocked while the notification callback has not returned.
+     *
+     * @param[in] callback Function, called after receiving an notification
+     *            message from camera (without any header information, like
+     *            ticket, length, etc.)
+     *
+     * @return Callback id, which can be used to cancel receiving
+     * notifications.
+     */
+    long SetNotificationCallback(
+      std::function<void(const std::string& notification)> callback);
 
-	/**
-	* Cancels registered callbacks. Must be called in case references/pointers
-	* provided through callbacks get invalid. If callback id isn't present
-	* internally anymore, i.e. if callback was replaced, already canceled or
-	* automatically removed (in case of the Call method), it is simply ignored.
-	*
-	* @param[in] callback_id Callback id, returned by methods which take a
-	*                        callback as parameter.
-	*/
-	void CancelCallback(long callback_id);
-
-  private:
-	  /**
-	  * Commands consist of content data surrounded by some meta data.
-	  * The State enum provides information which buffer is currently
-	  * used in writing to and reading from network
-	  */
-	  enum class State { PRE_CONTENT, CONTENT, POST_CONTENT };
-
-	  /**
-	  * Connects to the camera
-	  */
-	  void DoConnect();
-
-	  /**
-	  * Handles DoConnect results
-	  */
-	  void ConnectHandler(const boost::system::error_code& ec);
-
-	  /**
-	  * Reads data from network into one of the three "in" buffers
-	  * depending on current reading state.
-	  */
-	  void DoRead(State state, std::size_t bytes_remaining = UNSET);
-
-	  /**
-	  * Handles DoRead results: Triggers further reads and in
-	  * case an incoming message is completely received, does
-	  * the callback (if existent).
-	  */
-	  void ReadHandler(State state, const boost::system::error_code& ec,
-		  std::size_t bytes_transferred,
-		  std::size_t bytes_remaining);
-
-	  /**
-	  * Returns buffer to be filled from network depending on
-	  * specified reading state
-	  */
-	  std::string& InBufferByState(State state);
-
-	  /**
-	  * Writes data to network from one of the three "out" buffers
-	  * depending on current writing state.
-	  */
-	  void DoWrite(State state,
-		  const std::string &out_content_buffer,
-		  std::size_t bytes_remaining = UNSET);
-
-	  /**
-	  * Handles DoWrite results: Triggers further writes and in
-	  * case a request is completely sent, unblocks calling thread.
-	  */
-	  void WriteHandler(State state,
-		  const boost::system::error_code& ec,
-		  std::size_t bytes_transferred,
-		  const std::string& out_content_buffer,
-		  std::size_t bytes_remaining);
-
-	  /**
-	  * Returns buffer containing data to be written to network
-	  * depending on specified writing state. (In case of state CONTENT,
-	  * the specified out_content_buffer is returned.)
-	  */
-	  const std::string& OutBufferByState(State state,
-		  const std::string& out_content_buffer);
-
-	  /**
-	  * Finds and returns the next free ticket for a command
-	  */
-	  int NextCommandTicket();
-
-	  /**
-	  * Calculates and returns next callback id
-	  */
-	  long NextCallbackId();
+    /**
+     * Cancels registered callbacks. Must be called in case references/pointers
+     * provided through callbacks get invalid. If callback id isn't present
+     * internally anymore, i.e. if callback was replaced, already canceled or
+     * automatically removed (in case of the Call method), it is simply
+     * ignored.
+     *
+     * @param[in] callback_id Callback id, returned by methods which take a
+     *                        callback as parameter.
+     */
+    void CancelCallback(long callback_id);
 
   private:
-  /**
+    /**
+     * Commands consist of content data surrounded by some meta data.
+     * The State enum provides information which buffer is currently
+     * used in writing to and reading from network
+     */
+    enum class State
+    {
+      PRE_CONTENT,
+      CONTENT,
+      POST_CONTENT
+    };
+
+    /**
+     * Connects to the camera
+     */
+    void DoConnect();
+
+    /**
+     * Handles DoConnect results
+     */
+    void ConnectHandler(const boost::system::error_code& ec);
+
+    /**
+     * Reads data from network into one of the three "in" buffers
+     * depending on current reading state.
+     */
+    void DoRead(State state, std::size_t bytes_remaining = UNSET);
+
+    /**
+     * Handles DoRead results: Triggers further reads and in
+     * case an incoming message is completely received, does
+     * the callback (if existent).
+     */
+    void ReadHandler(State state,
+                     const boost::system::error_code& ec,
+                     std::size_t bytes_transferred,
+                     std::size_t bytes_remaining);
+
+    /**
+     * Returns buffer to be filled from network depending on
+     * specified reading state
+     */
+    std::string& InBufferByState(State state);
+
+    /**
+     * Writes data to network from one of the three "out" buffers
+     * depending on current writing state.
+     */
+    void DoWrite(State state,
+                 const std::string& out_content_buffer,
+                 std::size_t bytes_remaining = UNSET);
+
+    /**
+     * Handles DoWrite results: Triggers further writes and in
+     * case a request is completely sent, unblocks calling thread.
+     */
+    void WriteHandler(State state,
+                      const boost::system::error_code& ec,
+                      std::size_t bytes_transferred,
+                      const std::string& out_content_buffer,
+                      std::size_t bytes_remaining);
+
+    /**
+     * Returns buffer containing data to be written to network
+     * depending on specified writing state. (In case of state CONTENT,
+     * the specified out_content_buffer is returned.)
+     */
+    const std::string& OutBufferByState(State state,
+                                        const std::string& out_content_buffer);
+
+    /**
+     * Finds and returns the next free ticket for a command
+     */
+    int NextCommandTicket();
+
+    /**
+     * Calculates and returns next callback id
+     */
+    long NextCallbackId();
+
+  private:
+    /**
      * Init command sequence
      */
     static const std::string init_command;
@@ -309,8 +319,8 @@ namespace ifm3d
      * Sequential id for callbacks. Used in two-stage mapping:
      * 1) ticket to callback id
      * 2) callback id to callback
-     * Using callback ids for cancelling callbacks instead of tickets eliminates
-     * the risk of cancelling a newer callback with the same ticket.
+     * Using callback ids for cancelling callbacks instead of tickets
+     * eliminates the risk of cancelling a newer callback with the same ticket.
      */
     unsigned long current_callback_id_;
 
@@ -395,53 +405,52 @@ namespace ifm3d
 
 // Init command sequence to deactivate asynchronous result messages and
 // activate asynchronous error and notification messages (command: p6)
-const std::string ifm3d::PCICClient::Impl::init_command = "9999L000000008\r\n9999p6\r\n";
+const std::string ifm3d::PCICClient::Impl::init_command =
+  "9999L000000008\r\n9999p6\r\n";
 
 //-------------------------------------
 // ctor/dtor
 //-------------------------------------
 ifm3d::PCICClient::Impl::Impl(ifm3d::Camera::Ptr cam)
-	: cam_(cam),
-	connected_(false),
-	io_service_(),
-	sock_(io_service_),
-	current_callback_id_(0),
-	in_pre_content_buffer_(ifm3d::PRE_CONTENT_BUFFER_LENGTH, ' '),
-	in_content_buffer_(),
-	in_post_content_buffer_(ifm3d::POST_CONTENT_BUFFER_LENGTH, ' '),
-	out_pre_content_buffer_(ifm3d::PRE_CONTENT_BUFFER_LENGTH, ' '),
-	out_post_content_buffer_("\r\n")
+  : cam_(cam),
+    connected_(false),
+    io_service_(),
+    sock_(io_service_),
+    current_callback_id_(0),
+    in_pre_content_buffer_(ifm3d::PRE_CONTENT_BUFFER_LENGTH, ' '),
+    in_content_buffer_(),
+    in_post_content_buffer_(ifm3d::POST_CONTENT_BUFFER_LENGTH, ' '),
+    out_pre_content_buffer_(ifm3d::PRE_CONTENT_BUFFER_LENGTH, ' '),
+    out_post_content_buffer_("\r\n")
 {
-	try
-	{
-		this->cam_ip_ = this->cam_->IP();
-		this->cam_port_ = std::stoi(this->cam_->DeviceParameter("PcicTcpPort"));
-	}
-	catch (const ifm3d::error_t& ex)
-	{
-		LOG(ERROR) << "Could not get IP/Port of the camera: "
-			<< ex.what();
-		// NOTE: GetIP() won't throw, so, the problem must be getting the PCIC
-		// port. Here we assume the default. Former behavior was to throw!
-		LOG(WARNING) << "Assuming default PCIC port!";
-		this->cam_port_ = ifm3d::DEFAULT_PCIC_PORT;
-	}
+  try
+    {
+      this->cam_ip_ = this->cam_->IP();
+      this->cam_port_ = std::stoi(this->cam_->DeviceParameter("PcicTcpPort"));
+    }
+  catch (const ifm3d::error_t& ex)
+    {
+      LOG(ERROR) << "Could not get IP/Port of the camera: " << ex.what();
+      // NOTE: GetIP() won't throw, so, the problem must be getting the PCIC
+      // port. Here we assume the default. Former behavior was to throw!
+      LOG(WARNING) << "Assuming default PCIC port!";
+      this->cam_port_ = ifm3d::DEFAULT_PCIC_PORT;
+    }
 
-	LOG(INFO) << "Camera connection info: ip=" << this->cam_ip_
-		<< ", port=" << this->cam_port_;
+  LOG(INFO) << "Camera connection info: ip=" << this->cam_ip_
+            << ", port=" << this->cam_port_;
 
-	if (this->cam_->IsO3X())
-	{
-		throw ifm3d::error_t(IFM3D_PCICCLIENT_UNSUPPORTED_DEVICE);
-	}
+  if (this->cam_->IsO3X())
+    {
+      throw ifm3d::error_t(IFM3D_PCICCLIENT_UNSUPPORTED_DEVICE);
+    }
 
-	this->endpoint_ =
-		boost::asio::ip::tcp::endpoint(
-			boost::asio::ip::address::from_string(this->cam_ip_), this->cam_port_);
+  this->endpoint_ = boost::asio::ip::tcp::endpoint(
+    boost::asio::ip::address::from_string(this->cam_ip_),
+    this->cam_port_);
 
-	this->thread_ =
-		std::unique_ptr<std::thread>(
-			new std::thread(std::bind(&ifm3d::PCICClient::Impl::DoConnect, this)));
+  this->thread_ = std::unique_ptr<std::thread>(
+    new std::thread(std::bind(&ifm3d::PCICClient::Impl::DoConnect, this)));
 }
 
 ifm3d::PCICClient::Impl::~Impl()
@@ -460,69 +469,70 @@ ifm3d::PCICClient::Impl::~Impl()
 void
 ifm3d::PCICClient::Impl::Stop()
 {
-	this->io_service_.post([]() {
-		throw ifm3d::error_t(IFM3D_THREAD_INTERRUPTED); });
+  this->io_service_.post(
+    []() { throw ifm3d::error_t(IFM3D_THREAD_INTERRUPTED); });
 }
 
 long
-ifm3d::PCICClient::Impl::Call(const std::string& request,
-	std::function<void(const std::string& response)> callback)
+ifm3d::PCICClient::Impl::Call(
+  const std::string& request,
+  std::function<void(const std::string& response)> callback)
 {
-	// TODO Better solution for this connection waiting ..
-	int i = 0;
-	while (!this->connected_.load())
-	{
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		i++;
+  // TODO Better solution for this connection waiting ..
+  int i = 0;
+  while (!this->connected_.load())
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      i++;
 
-		if (i > ifm3d::CONNECTED_FLAG_TIMEOUT)
-		{
-			LOG(WARNING) << "connected_ flag not set!";
-			return -1;
-		}
-	}
+      if (i > ifm3d::CONNECTED_FLAG_TIMEOUT)
+        {
+          LOG(WARNING) << "connected_ flag not set!";
+          return -1;
+        }
+    }
 
-	// PCICClient is unbuffered, so block further calls
-	std::unique_lock<std::mutex> out_mutex_lock(this->out_mutex_);
+  // PCICClient is unbuffered, so block further calls
+  std::unique_lock<std::mutex> out_mutex_lock(this->out_mutex_);
 
-	this->out_completed_.store(false);
+  this->out_completed_.store(false);
 
-	// Sync access to ticket and id generation
-	// as well as to ticket/id and id/callback maps
-	std::unique_lock<std::mutex> data_sync_lock(this->data_sync_mutex_);
+  // Sync access to ticket and id generation
+  // as well as to ticket/id and id/callback maps
+  std::unique_lock<std::mutex> data_sync_lock(this->data_sync_mutex_);
 
-	// Get next command ticket and callback id
-	int ticket = this->NextCommandTicket();
-	long callback_id = this->NextCallbackId();
+  // Get next command ticket and callback id
+  int ticket = this->NextCommandTicket();
+  long callback_id = this->NextCallbackId();
 
-	// Add mappings: ticket -> callback id; callback id -> callback
-	this->ticket_to_callback_id_[ticket] = callback_id;
-	this->pending_callbacks_[callback_id] = callback;
+  // Add mappings: ticket -> callback id; callback id -> callback
+  this->ticket_to_callback_id_[ticket] = callback_id;
+  this->pending_callbacks_[callback_id] = callback;
 
-	data_sync_lock.unlock();
+  data_sync_lock.unlock();
 
+  // Transform ticket and length to string
+  std::ostringstream pre_content_ss;
+  pre_content_ss << ticket << 'L' << std::setw(9) << std::setfill('0')
+                 << (request.size() + 6) << "\r\n"
+                 << ticket;
 
-	// Transform ticket and length to string
-	std::ostringstream pre_content_ss;
-	pre_content_ss << ticket << 'L' << std::setw(9) << std::setfill('0')
-		<< (request.size() + 6) << "\r\n" << ticket;
+  // Prepare pre content buffer
+  this->out_pre_content_buffer_ = pre_content_ss.str();
 
-	// Prepare pre content buffer
-	this->out_pre_content_buffer_ = pre_content_ss.str();
+  DLOG(INFO) << "Client sending request";
 
-	DLOG(INFO) << "Client sending request";
+  // Send command
+  this->DoWrite(State::PRE_CONTENT, request);
 
-	// Send command
-	this->DoWrite(State::PRE_CONTENT, request);
+  // Wait until sending is complete
+  while (!this->out_completed_.load())
+    {
+      this->out_cv_.wait(out_mutex_lock);
+    }
+  out_mutex_lock.unlock();
 
-	// Wait until sending is complete
-	while (!this->out_completed_.load())
-	{
-		this->out_cv_.wait(out_mutex_lock);
-	}
-	out_mutex_lock.unlock();
-
-	return callback_id;
+  return callback_id;
 }
 
 std::string
@@ -533,106 +543,108 @@ ifm3d::PCICClient::Impl::Call(const std::string& request)
   return response;
 }
 
-bool/* @R Consider boost::asio::error return type here */
-ifm3d::PCICClient::Impl::Call(const std::string& request, std::string& response, long timeout_millis)
+bool /* @R Consider boost::asio::error return type here */
+ifm3d::PCICClient::Impl::Call(const std::string& request,
+                              std::string& response,
+                              long timeout_millis)
 {
   std::atomic_bool has_result(false);
   long call_output = -1;
 
   // Handle the PCIC Call
 
-  std::unique_ptr<std::thread> call_thread_ = std::make_unique<std::thread>([&]{
-  call_output = Call(request, [&](const std::string& content)
-  {
-    // Copy content, notify and leave callback
-    response = content;
-    std::unique_lock<std::mutex> lock(this->in_mutex_);
-    has_result.store(true);
-    this->in_cv_.notify_all();
+  std::unique_ptr<std::thread> call_thread_ =
+    std::make_unique<std::thread>([&] {
+      call_output = Call(request, [&](const std::string& content) {
+        // Copy content, notify and leave callback
+        response = content;
+        std::unique_lock<std::mutex> lock(this->in_mutex_);
+        has_result.store(true);
+        this->in_cv_.notify_all();
+      });
+    });
 
-  });
+  if (call_thread_ && call_thread_->joinable())
+    call_thread_->join();
 
-  });
-
-  if(call_thread_ && call_thread_->joinable()) call_thread_->join();
-  
   // Check the return value of our PCIC Call
-  if(call_output > 0)
-  {
-    std::unique_lock<std::mutex> lock(this->in_mutex_);
-    try
+  if (call_output > 0)
     {
-      if (timeout_millis <= 0)
-      {
-        this->in_cv_.wait(lock, [&]{return has_result.load();});
-      }
-
-      else
-      {
-        if (this->in_cv_.wait_for(
-              lock, std::chrono::milliseconds(timeout_millis)) ==
-            std::cv_status::timeout)
+      std::unique_lock<std::mutex> lock(this->in_mutex_);
+      try
         {
-          this->in_cv_.notify_all();
-          if(this->thread_ && this->thread_->joinable())
-          {
-          	this->Stop();
-          	this->thread_->join();
-          }
+          if (timeout_millis <= 0)
+            {
+              this->in_cv_.wait(lock, [&] { return has_result.load(); });
+            }
+
+          else
+            {
+              if (this->in_cv_.wait_for(
+                    lock,
+                    std::chrono::milliseconds(timeout_millis)) ==
+                  std::cv_status::timeout)
+                {
+                  this->in_cv_.notify_all();
+                  if (this->thread_ && this->thread_->joinable())
+                    {
+                      this->Stop();
+                      this->thread_->join();
+                    }
+                  return has_result.load();
+                }
+
+              else
+                {
+                  this->in_cv_.wait(lock, [&] { return has_result.load(); });
+                }
+            }
+        }
+
+      catch (const std::system_error& ex)
+        {
+          LOG(WARNING) << "PCICClient::Call: " << ex.what();
           return has_result.load();
         }
-
-        else
-        {
-          this->in_cv_.wait(lock, [&]{return has_result.load();});
-        }
-      }
     }
-
-    catch (const std::system_error& ex)
-    {
-      LOG(WARNING) << "PCICClient::Call: " << ex.what();
-      return has_result.load();
-    }
-  }
 
   return has_result.load();
 }
 
 long
-ifm3d::PCICClient
-::Impl::SetErrorCallback(std::function<void(const std::string& error)> callback)
+ifm3d::PCICClient ::Impl::SetErrorCallback(
+  std::function<void(const std::string& error)> callback)
 {
-	std::unique_lock<std::mutex> lock(this->data_sync_mutex_);
-	long callback_id = this->NextCallbackId();
+  std::unique_lock<std::mutex> lock(this->data_sync_mutex_);
+  long callback_id = this->NextCallbackId();
 
-	// Asynchronous error messages always have ticket '0001'
-	this->ticket_to_callback_id_[1] = callback_id;
-	this->pending_callbacks_[callback_id] = callback;
-	lock.unlock();
-	return callback_id;
+  // Asynchronous error messages always have ticket '0001'
+  this->ticket_to_callback_id_[1] = callback_id;
+  this->pending_callbacks_[callback_id] = callback;
+  lock.unlock();
+  return callback_id;
 }
 
 long
-ifm3d::PCICClient
-::Impl::SetNotificationCallback(std::function<void(const std::string& notification)> callback)
+ifm3d::PCICClient ::Impl::SetNotificationCallback(
+  std::function<void(const std::string& notification)> callback)
 {
-	std::unique_lock<std::mutex> lock(this->data_sync_mutex_);
-	long callback_id = this->NextCallbackId();
+  std::unique_lock<std::mutex> lock(this->data_sync_mutex_);
+  long callback_id = this->NextCallbackId();
 
-	// Asynchronous notification messages always have ticket '0010'
-	this->ticket_to_callback_id_[10] = callback_id;
-	this->pending_callbacks_[callback_id] = callback;
-	lock.unlock();
-	return callback_id;
+  // Asynchronous notification messages always have ticket '0010'
+  this->ticket_to_callback_id_[10] = callback_id;
+  this->pending_callbacks_[callback_id] = callback;
+  lock.unlock();
+  return callback_id;
 }
 
 void
 ifm3d::PCICClient::Impl::CancelCallback(long callback_id)
 {
-	std::unique_lock<std::mutex> lock(this->data_sync_mutex_);
-	this->pending_callbacks_.erase(callback_id);
-	lock.unlock();
+  std::unique_lock<std::mutex> lock(this->data_sync_mutex_);
+  this->pending_callbacks_.erase(callback_id);
+  lock.unlock();
 }
 
 void
@@ -643,14 +655,16 @@ ifm3d::PCICClient::Impl::DoConnect()
   // Establish TCP connection to sensor
   try
     {
-      this->sock_.async_connect(this->endpoint_,
-				std::bind(&ifm3d::PCICClient::Impl::ConnectHandler,
-					  this, std::placeholders::_1));
+      this->sock_.async_connect(
+        this->endpoint_,
+        std::bind(&ifm3d::PCICClient::Impl::ConnectHandler,
+                  this,
+                  std::placeholders::_1));
       this->io_service_.run();
     }
-  catch(const std::exception& ex)
+  catch (const std::exception& ex)
     {
-        LOG(WARNING) << "Exception: " << ex.what();
+      LOG(WARNING) << "Exception: " << ex.what();
     }
 
   LOG(INFO) << "PCICClient thread done.";
@@ -659,49 +673,58 @@ ifm3d::PCICClient::Impl::DoConnect()
 void
 ifm3d::PCICClient::Impl::ConnectHandler(const boost::system::error_code& ec)
 {
-  if(ec) { throw ifm3d::error_t(ec.value()); }
+  if (ec)
+    {
+      throw ifm3d::error_t(ec.value());
+    }
   this->DoRead(State::PRE_CONTENT);
 
   // Write init command sequence to turn off asynchronous messages
-  boost::asio::async_write(this->sock_,
-			   boost::asio::buffer(&init_command[0],
-					       init_command.size()),
-			   [&, this]
-			   (const boost::system::error_code& ec,
-			    std::size_t bytes_transferred)
-			   {
-			     if (ec) { throw ifm3d::error_t(ec.value()); }
-			     this->connected_.store(true);
-			   });
+  boost::asio::async_write(
+    this->sock_,
+    boost::asio::buffer(&init_command[0], init_command.size()),
+    [&, this](const boost::system::error_code& ec,
+              std::size_t bytes_transferred) {
+      if (ec)
+        {
+          throw ifm3d::error_t(ec.value());
+        }
+      this->connected_.store(true);
+    });
 }
 
 void
 ifm3d::PCICClient::Impl::DoRead(State state, std::size_t bytes_remaining)
 {
-  std::string &buffer = this->InBufferByState(state);
-  if(bytes_remaining==UNSET)
+  std::string& buffer = this->InBufferByState(state);
+  if (bytes_remaining == UNSET)
     {
       bytes_remaining = buffer.size();
     }
 
   this->sock_.async_read_some(
-			      boost::asio::buffer(&buffer[buffer.size()-bytes_remaining],
-						  bytes_remaining),
-			      std::bind(&ifm3d::PCICClient::Impl::ReadHandler,
-					this,
-					state,
-					std::placeholders::_1,
-					std::placeholders::_2,
-					bytes_remaining));
+    boost::asio::buffer(&buffer[buffer.size() - bytes_remaining],
+                        bytes_remaining),
+    std::bind(&ifm3d::PCICClient::Impl::ReadHandler,
+              this,
+              state,
+              std::placeholders::_1,
+              std::placeholders::_2,
+              bytes_remaining));
 }
 
 void
-ifm3d::PCICClient::Impl::ReadHandler(State state, const boost::system::error_code& ec,
-				std::size_t bytes_transferred, std::size_t bytes_remaining)
+ifm3d::PCICClient::Impl::ReadHandler(State state,
+                                     const boost::system::error_code& ec,
+                                     std::size_t bytes_transferred,
+                                     std::size_t bytes_remaining)
 {
-  if(ec) { throw ifm3d::error_t(ec.value()); }
+  if (ec)
+    {
+      throw ifm3d::error_t(ec.value());
+    }
 
-  if(bytes_remaining - bytes_transferred > 0)
+  if (bytes_remaining - bytes_transferred > 0)
     {
       this->DoRead(state, bytes_remaining - bytes_transferred);
     }
@@ -709,132 +732,148 @@ ifm3d::PCICClient::Impl::ReadHandler(State state, const boost::system::error_cod
     {
       int ticket;
       int length;
-      switch(state)
-	{
-	case State::PRE_CONTENT:
-	  length = std::stoi(this->in_pre_content_buffer_.substr(5, 9));
-	  this->in_content_buffer_.resize(length-6);
-	  this->DoRead(State::CONTENT);
-	  break;
+      switch (state)
+        {
+        case State::PRE_CONTENT:
+          length = std::stoi(this->in_pre_content_buffer_.substr(5, 9));
+          this->in_content_buffer_.resize(length - 6);
+          this->DoRead(State::CONTENT);
+          break;
 
-	case State::CONTENT:
-	  this->DoRead(State::POST_CONTENT);
-	  break;
+        case State::CONTENT:
+          this->DoRead(State::POST_CONTENT);
+          break;
 
-	case State::POST_CONTENT:
-	  ticket = std::stoi(this->in_pre_content_buffer_.substr(0, 4));
-	  this->data_sync_mutex_.lock();
-	  try
-	    {
-	      // Get callback id
-	      long callback_id = this->ticket_to_callback_id_.at(ticket);
+        case State::POST_CONTENT:
+          ticket = std::stoi(this->in_pre_content_buffer_.substr(0, 4));
+          this->data_sync_mutex_.lock();
+          try
+            {
+              // Get callback id
+              long callback_id = this->ticket_to_callback_id_.at(ticket);
 
-	      // Erase mapping if it is a one-time ticket triggered by a Call method
-	      if(ticket >= ifm3d::ONE_TIME_TICKET_LOWER_RANGE && ticket <= ifm3d::ONE_TIME_TICKET_HIGHER_RANGE)
-		  {
-			this->ticket_to_callback_id_.erase(ticket);
-		  }
+              // Erase mapping if it is a one-time ticket triggered by a Call
+              // method
+              if (ticket >= ifm3d::ONE_TIME_TICKET_LOWER_RANGE &&
+                  ticket <= ifm3d::ONE_TIME_TICKET_HIGHER_RANGE)
+                {
+                  this->ticket_to_callback_id_.erase(ticket);
+                }
 
-	      // Execute callback
-	      this->pending_callbacks_.at(callback_id)(this->in_content_buffer_);
+              // Execute callback
+              this->pending_callbacks_.at(callback_id)(
+                this->in_content_buffer_);
 
-	      // Erase mapping if it is a one-time ticket triggered by a Call method
-		  if (ticket >= ifm3d::ONE_TIME_TICKET_LOWER_RANGE && ticket <= ifm3d::ONE_TIME_TICKET_HIGHER_RANGE)
-		  {
-			this->pending_callbacks_.erase(callback_id);
-		  }
-	    }
-	  catch(std::out_of_range ex)
-	    {
-	      DLOG(INFO) << "No callback for ticket " << ticket << " found!";
-	    }
-	  this->data_sync_mutex_.unlock();
-	  this->DoRead(State::PRE_CONTENT);
-	  break;
-	}
+              // Erase mapping if it is a one-time ticket triggered by a Call
+              // method
+              if (ticket >= ifm3d::ONE_TIME_TICKET_LOWER_RANGE &&
+                  ticket <= ifm3d::ONE_TIME_TICKET_HIGHER_RANGE)
+                {
+                  this->pending_callbacks_.erase(callback_id);
+                }
+            }
+          catch (std::out_of_range ex)
+            {
+              DLOG(INFO) << "No callback for ticket " << ticket << " found!";
+            }
+          this->data_sync_mutex_.unlock();
+          this->DoRead(State::PRE_CONTENT);
+          break;
+        }
     }
 }
 
 std::string&
 ifm3d::PCICClient::Impl::InBufferByState(State state)
 {
-  switch(state)
+  switch (state)
     {
-    case State::PRE_CONTENT: return this->in_pre_content_buffer_;
-    case State::CONTENT: return this->in_content_buffer_;
-    case State::POST_CONTENT: return this->in_post_content_buffer_;
+    case State::PRE_CONTENT:
+      return this->in_pre_content_buffer_;
+    case State::CONTENT:
+      return this->in_content_buffer_;
+    case State::POST_CONTENT:
+      return this->in_post_content_buffer_;
     }
   throw;
 }
 
 void
 ifm3d::PCICClient::Impl::DoWrite(State state,
-			    const std::string& out_content_buffer,
-			    std::size_t bytes_remaining)
+                                 const std::string& out_content_buffer,
+                                 std::size_t bytes_remaining)
 {
-  const std::string &buffer = this->OutBufferByState(state, out_content_buffer);
-  if(bytes_remaining==UNSET)
+  const std::string& buffer =
+    this->OutBufferByState(state, out_content_buffer);
+  if (bytes_remaining == UNSET)
     {
       bytes_remaining = buffer.size();
     }
 
   this->sock_.async_write_some(
-			      boost::asio::buffer(&buffer[buffer.size()
-							  -bytes_remaining],
-						  bytes_remaining),
-			      std::bind(&ifm3d::PCICClient::Impl::WriteHandler,
-					this,
-					state,
-					std::placeholders::_1,
-					std::placeholders::_2,
-					out_content_buffer,
-					bytes_remaining));
+    boost::asio::buffer(&buffer[buffer.size() - bytes_remaining],
+                        bytes_remaining),
+    std::bind(&ifm3d::PCICClient::Impl::WriteHandler,
+              this,
+              state,
+              std::placeholders::_1,
+              std::placeholders::_2,
+              out_content_buffer,
+              bytes_remaining));
 }
 
 void
 ifm3d::PCICClient::Impl::WriteHandler(State state,
-				 const boost::system::error_code& ec,
-				 std::size_t bytes_transferred,
-				 const std::string& out_content_buffer,
-				 std::size_t bytes_remaining)
+                                      const boost::system::error_code& ec,
+                                      std::size_t bytes_transferred,
+                                      const std::string& out_content_buffer,
+                                      std::size_t bytes_remaining)
 {
-  if(ec) { throw ifm3d::error_t(ec.value()); }
-
-  if(bytes_remaining - bytes_transferred > 0)
+  if (ec)
     {
-      this->DoWrite(state, out_content_buffer,
-		    bytes_remaining - bytes_transferred);
+      throw ifm3d::error_t(ec.value());
+    }
+
+  if (bytes_remaining - bytes_transferred > 0)
+    {
+      this->DoWrite(state,
+                    out_content_buffer,
+                    bytes_remaining - bytes_transferred);
     }
   else
     {
-      switch(state)
-	{
-	case State::PRE_CONTENT:
-	  this->DoWrite(State::CONTENT, out_content_buffer);
-	  break;
+      switch (state)
+        {
+        case State::PRE_CONTENT:
+          this->DoWrite(State::CONTENT, out_content_buffer);
+          break;
 
-	case State::CONTENT:
-	  this->DoWrite(State::POST_CONTENT, out_content_buffer);
-	  break;
+        case State::CONTENT:
+          this->DoWrite(State::POST_CONTENT, out_content_buffer);
+          break;
 
-	case State::POST_CONTENT:
-	  std::unique_lock<std::mutex> lock(this->out_mutex_);
-	  this->out_completed_.store(true);
-	  this->out_cv_.notify_all();
-	  break;
-	}
+        case State::POST_CONTENT:
+          std::unique_lock<std::mutex> lock(this->out_mutex_);
+          this->out_completed_.store(true);
+          this->out_cv_.notify_all();
+          break;
+        }
     }
 }
 
 const std::string&
-ifm3d::PCICClient::Impl::OutBufferByState(State state,
-				     const std::string& out_content_buffer)
+ifm3d::PCICClient::Impl::OutBufferByState(
+  State state,
+  const std::string& out_content_buffer)
 {
-  switch(state)
+  switch (state)
     {
-    case State::PRE_CONTENT: return this->out_pre_content_buffer_;
-    case State::CONTENT: return out_content_buffer;
-    case State::POST_CONTENT: return this->out_post_content_buffer_;
+    case State::PRE_CONTENT:
+      return this->out_pre_content_buffer_;
+    case State::CONTENT:
+      return out_content_buffer;
+    case State::POST_CONTENT:
+      return this->out_post_content_buffer_;
     }
   throw;
 }
@@ -842,19 +881,28 @@ ifm3d::PCICClient::Impl::OutBufferByState(State state,
 int
 ifm3d::PCICClient::Impl::NextCommandTicket()
 {
-  const auto number_of_one_time_tickets = ONE_TIME_TICKET_HIGHER_RANGE - ONE_TIME_TICKET_LOWER_RANGE + 1;
+  const auto number_of_one_time_tickets =
+    ONE_TIME_TICKET_HIGHER_RANGE - ONE_TIME_TICKET_LOWER_RANGE + 1;
   int ticket = ifm3d::ONE_TIME_TICKET_LOWER_RANGE;
-  if(!this->ticket_to_callback_id_.empty())
+  if (!this->ticket_to_callback_id_.empty())
     {
-      ticket = (this->ticket_to_callback_id_.rbegin()->first)- ifm3d::ONE_TIME_TICKET_LOWER_RANGE;
+      ticket = (this->ticket_to_callback_id_.rbegin()->first) -
+               ifm3d::ONE_TIME_TICKET_LOWER_RANGE;
 
       // Ignore error/notification message tickets when generating
       // new command tickets
-      if(ticket<0) { ticket = 0; }
+      if (ticket < 0)
+        {
+          ticket = 0;
+        }
 
-      while(this->ticket_to_callback_id_.find(((++ticket)% number_of_one_time_tickets) + ifm3d::ONE_TIME_TICKET_LOWER_RANGE)
-	    != this->ticket_to_callback_id_.end());
-      ticket = (ticket% number_of_one_time_tickets) + ifm3d::ONE_TIME_TICKET_LOWER_RANGE;
+      while (this->ticket_to_callback_id_.find(
+               ((++ticket) % number_of_one_time_tickets) +
+               ifm3d::ONE_TIME_TICKET_LOWER_RANGE) !=
+             this->ticket_to_callback_id_.end())
+        ;
+      ticket = (ticket % number_of_one_time_tickets) +
+               ifm3d::ONE_TIME_TICKET_LOWER_RANGE;
     }
   return ticket;
 }
@@ -862,8 +910,8 @@ ifm3d::PCICClient::Impl::NextCommandTicket()
 long
 ifm3d::PCICClient::Impl::NextCallbackId()
 {
-  return (this->current_callback_id_ == 0)? (this->current_callback_id_ = 1) : (++this->current_callback_id_) ;
+  return (this->current_callback_id_ == 0) ? (this->current_callback_id_ = 1) :
+                                             (++this->current_callback_id_);
 }
-
 
 #endif // __IFM3D_PCICCLIENT_PCICCLIENT_IMPL_H__

--- a/modules/pcicclient/test/ifm3d-pcicclient-testrunner.cpp
+++ b/modules/pcicclient/test/ifm3d-pcicclient-testrunner.cpp
@@ -1,7 +1,8 @@
 #include <ifm3d/pcicclient.h>
 #include <gtest/gtest.h>
 
-int main(int argc, char **argv)
+int
+main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/modules/pcicclient/test/ifm3d-pcicclient-tests.cpp
+++ b/modules/pcicclient/test/ifm3d-pcicclient-tests.cpp
@@ -9,15 +9,15 @@
 class PCICClientTest : public ::testing::Test
 {
 protected:
-  virtual void SetUp()
+  virtual void
+  SetUp()
   {
     this->cam_ = ifm3d::Camera::MakeShared();
   }
 
-  virtual void TearDown()
-  {
-
-  }
+  virtual void
+  TearDown()
+  { }
 
   ifm3d::Camera::Ptr cam_;
 };
@@ -36,7 +36,7 @@ TEST_F(PCICClientTest, IncomingResponseMessage)
 
   ifm3d::PCICClient::Ptr pc = std::make_shared<ifm3d::PCICClient>(cam_);
 
-  for(int i = 0; i < 5; ++i)
+  for (int i = 0; i < 5; ++i)
     {
       std::string result = pc->Call("C?");
       EXPECT_GT(result.size(), 0);
@@ -59,7 +59,7 @@ TEST_F(PCICClientTest, InvalidCommandLength)
 
   ifm3d::PCICClient::Ptr pc = std::make_shared<ifm3d::PCICClient>(cam_);
 
-  for(int i = 0; i < 5; ++i)
+  for (int i = 0; i < 5; ++i)
     {
       std::string result = pc->Call("Ca?");
       EXPECT_STREQ(result.c_str(), "?");
@@ -83,27 +83,27 @@ TEST_F(PCICClientTest, PCICTimeout)
 
   ifm3d::PCICClient::Ptr pc = std::make_shared<ifm3d::PCICClient>(cam_);
 
-  std::unique_ptr<std::thread> reboot_thread_ = std::make_unique<std::thread>([&]{
+  std::unique_ptr<std::thread> reboot_thread_ =
+    std::make_unique<std::thread>([&] {
+      EXPECT_NO_THROW(
+        this->cam_->Reboot(ifm3d::Camera::boot_mode::PRODUCTIVE));
 
-  EXPECT_NO_THROW(this->cam_->Reboot(ifm3d::Camera::boot_mode::PRODUCTIVE));
+      std::this_thread::sleep_for(std::chrono::seconds(5));
+    });
 
-  std::this_thread::sleep_for(std::chrono::seconds(5));
+  if (reboot_thread_ && reboot_thread_->joinable())
+    reboot_thread_->join();
 
-  });
-
-  if(reboot_thread_ && reboot_thread_->joinable()) reboot_thread_->join();
-
-  for(int i = 0; i < 20; ++i)
+  for (int i = 0; i < 20; ++i)
     {
       result.clear();
 
-      if(!pc->Call("V?",result,5000))
-       {
-         pc = std::make_shared<ifm3d::PCICClient>(cam_);
-       }
+      if (!pc->Call("V?", result, 5000))
+        {
+          pc = std::make_shared<ifm3d::PCICClient>(cam_);
+        }
     }
 
   EXPECT_GT(result.size(), 0);
   pc->Stop();
-
 }

--- a/modules/pybind11/src/main.cpp
+++ b/modules/pybind11/src/main.cpp
@@ -95,24 +95,29 @@ namespace ifm3d
 
   FrameGrabberWrapper::FrameGrabberWrapper(ifm3d::Camera::Ptr cam,
                                            std::uint16_t mask)
-    : fg_(std::make_shared<ifm3d::FrameGrabber>(cam, mask)) {}
+    : fg_(std::make_shared<ifm3d::FrameGrabber>(cam, mask))
+  { }
 
-  void FrameGrabberWrapper::SWTrigger()
+  void
+  FrameGrabberWrapper::SWTrigger()
   {
     this->fg_->SWTrigger();
   }
 
-  bool FrameGrabberWrapper::WaitForFrame(
-      const ifm3d::OpenCVBuffer::Ptr& buff,
-      long timeout_millis,
-      bool copy_buff,
-      bool organize)
+  bool
+  FrameGrabberWrapper::WaitForFrame(const ifm3d::OpenCVBuffer::Ptr& buff,
+                                    long timeout_millis,
+                                    bool copy_buff,
+                                    bool organize)
   {
-    return this->fg_->WaitForFrame(buff.get(), timeout_millis,
-                                   copy_buff, organize);
+    return this->fg_->WaitForFrame(buff.get(),
+                                   timeout_millis,
+                                   copy_buff,
+                                   organize);
   }
 
-  void FrameGrabberWrapper::Reset(ifm3d::Camera::Ptr cam, std::uint16_t mask)
+  void
+  FrameGrabberWrapper::Reset(ifm3d::Camera::Ptr cam, std::uint16_t mask)
   {
     // Two distinct steps (required because O3X only accepts one connection)
     this->fg_.reset();
@@ -144,7 +149,7 @@ PYBIND11_MODULE(ifm3dpy, m)
   m.attr("IMG_UVEC") = ifm3d::IMG_UVEC;
   m.attr("EXP_TIME") = ifm3d::EXP_TIME;
   m.attr("IMG_GRAY") = ifm3d::IMG_GRAY;
-  m.attr("ILLU_TEMP")  = ifm3d::ILLU_TEMP;
+  m.attr("ILLU_TEMP") = ifm3d::ILLU_TEMP;
   m.attr("INTR_CAL") = ifm3d::INTR_CAL;
   m.attr("INV_INTR_CAL") = ifm3d::INV_INTR_CAL;
   m.attr("JSON_MODEL") = ifm3d::JSON_MODEL;

--- a/modules/pybind11/src/main.cpp
+++ b/modules/pybind11/src/main.cpp
@@ -172,6 +172,8 @@ PYBIND11_MODULE(ifm3dpy, m)
   m.attr("O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_PATCH") =
     ifm3d::O3D_INVERSE_INTRINSIC_PARAM_SUPPORT_PATCH;
 
+  // clang-format does a poor job handling the alignment of raw strings
+  // clang-format off
   py::class_<ifm3d::OpenCVBuffer, ifm3d::OpenCVBuffer::Ptr>(
     m,
     "ImageBuffer",
@@ -1212,4 +1214,5 @@ PYBIND11_MODULE(ifm3dpy, m)
           as descriptive as possible as to the specific error that has
           occured.
     )");
+  // clang-format on
 }

--- a/modules/pybind11/src/util.hpp
+++ b/modules/pybind11/src/util.hpp
@@ -27,52 +27,47 @@ namespace py = pybind11;
 
 namespace ifm3d
 {
-  template<typename T>
-  py::array_t<T> image_to_array_2d(const cv::Mat& img)
+  template <typename T>
+  py::array_t<T>
+  image_to_array_2d(const cv::Mat& img)
   {
     // Alloc a new cv::Mat_<T> and tie its lifecycle to the Python object
     // via a capsule. The resulting numpy.ndarray will not own the memory, but
     // the memory will remain valid for the lifecycle of the object.
     auto mat = new cv::Mat_<T>(img);
-    auto capsule = py::capsule(
-      mat,
-      [](void *m)
-      {
-        delete reinterpret_cast<cv::Mat_<cv::Vec<T, 3>>*>(m);
-      });
+    auto capsule = py::capsule(mat, [](void* m) {
+      delete reinterpret_cast<cv::Mat_<cv::Vec<T, 3>>*>(m);
+    });
 
-    return py::array_t<T>(
-      { mat->rows, mat->cols },
-      { sizeof(T) * mat->cols, sizeof(T)},
-      reinterpret_cast<T*>(mat->ptr(0)),
-      capsule);
+    return py::array_t<T>({mat->rows, mat->cols},
+                          {sizeof(T) * mat->cols, sizeof(T)},
+                          reinterpret_cast<T*>(mat->ptr(0)),
+                          capsule);
   }
 
-  template<typename T>
-  py::array_t<T> image_to_array_nd(const cv::Mat& cld)
+  template <typename T>
+  py::array_t<T>
+  image_to_array_nd(const cv::Mat& cld)
   {
     // Alloc a new cv::Mat_<T> and tie its lifecycle to the Python object
     // via a capsule. The resulting numpy.ndarray will not own the memory, but
     // the memory will remain valid for the lifecycle of the object.
     auto mat = new cv::Mat_<cv::Vec<T, 3>>(cld);
-    auto capsule = py::capsule(
-      mat,
-      [](void *m)
-      {
-        delete reinterpret_cast<cv::Mat_<cv::Vec<T, 3>>*>(m);
-      });
+    auto capsule = py::capsule(mat, [](void* m) {
+      delete reinterpret_cast<cv::Mat_<cv::Vec<T, 3>>*>(m);
+    });
 
-    return py::array_t<T>(
-      { mat->rows, mat->cols, mat->channels() },
-      { sizeof(T) * mat->channels() * mat->cols,
-        sizeof(T) * mat->channels(),
-        sizeof(T)},
-      reinterpret_cast<T*>(mat->ptr(0)),
-      capsule);
+    return py::array_t<T>({mat->rows, mat->cols, mat->channels()},
+                          {sizeof(T) * mat->channels() * mat->cols,
+                           sizeof(T) * mat->channels(),
+                           sizeof(T)},
+                          reinterpret_cast<T*>(mat->ptr(0)),
+                          capsule);
   }
 
-  template<typename T>
-  py::array_t<T> image_to_array_(const cv::Mat& img)
+  template <typename T>
+  py::array_t<T>
+  image_to_array_(const cv::Mat& img)
   {
     if (img.channels() > 1)
       {
@@ -84,10 +79,11 @@ namespace ifm3d
       }
   }
 
-  py::array image_to_array(const cv::Mat& img)
+  py::array
+  image_to_array(const cv::Mat& img)
   {
-    switch(img.depth())
-    {
+    switch (img.depth())
+      {
       case CV_8U:
         return image_to_array_<std::uint8_t>(img);
         break;
@@ -110,9 +106,8 @@ namespace ifm3d
         return image_to_array_<double>(img);
         break;
       default:
-        throw std::runtime_error(
-          "Unsupported CV type: " + img.type());
-    }
+        throw std::runtime_error("Unsupported CV type: " + img.type());
+      }
   }
 }
 

--- a/modules/swupdater/include/ifm3d/swupdater/swupdater_export.h
+++ b/modules/swupdater/include/ifm3d/swupdater/swupdater_export.h
@@ -7,7 +7,7 @@
 #  ifdef IFM3D_SWUPDATER_DLL_BUILD
 #    define IFM3D_SWUPDATER_EXPORT __declspec(dllexport)
 #  else
-#     define IFM3D_SWUPDATER_EXPORT __declspec(dllimport)
+#    define IFM3D_SWUPDATER_EXPORT __declspec(dllimport)
 #  endif
 #endif
 

--- a/modules/swupdater/src/libifm3d_swupdater/swupdater.cpp
+++ b/modules/swupdater/src/libifm3d_swupdater/swupdater.cpp
@@ -52,9 +52,8 @@ ifm3d::SWUpdater::WaitForProductive(long timeout_millis)
 }
 
 bool
-ifm3d::SWUpdater::FlashFirmware(
-    const std::vector<std::uint8_t>& bytes,
-    long timeout_millis)
+ifm3d::SWUpdater::FlashFirmware(const std::vector<std::uint8_t>& bytes,
+                                long timeout_millis)
 {
   return this->pImpl->FlashFirmware(bytes, timeout_millis);
 }

--- a/modules/swupdater/src/libifm3d_swupdater/swupdater_impl.hpp
+++ b/modules/swupdater/src/libifm3d_swupdater/swupdater_impl.hpp
@@ -47,7 +47,7 @@ namespace ifm3d
   const int SWUPDATER_STATUS_FAILURE = 4;
 
   // Default timeout values for cURL transactions to the camera
-  const long DEFAULT_CURL_CONNECT_TIMEOUT = 3; // seconds
+  const long DEFAULT_CURL_CONNECT_TIMEOUT = 3;      // seconds
   const long DEFAULT_CURL_TRANSACTION_TIMEOUT = 30; // seconds
 
   //============================================================
@@ -63,9 +63,8 @@ namespace ifm3d
     bool WaitForRecovery(long timeout_millis);
     void RebootToProductive();
     bool WaitForProductive(long timeout_millis);
-    bool FlashFirmware(
-      const std::vector<std::uint8_t>& bytes,
-      long timeout_millis);
+    bool FlashFirmware(const std::vector<std::uint8_t>& bytes,
+                       long timeout_millis);
 
   private:
     ifm3d::Camera::Ptr cam_;
@@ -76,35 +75,31 @@ namespace ifm3d
     std::string status_url_;
     std::string check_recovery_url_;
 
-    bool
-    CheckRecovery();
+    bool CheckRecovery();
 
-    bool
-    CheckProductive();
+    bool CheckProductive();
 
-    void
-    UploadFirmware(const std::vector<std::uint8_t>& bytes,
-                   long timeout_millis);
+    void UploadFirmware(const std::vector<std::uint8_t>& bytes,
+                        long timeout_millis);
 
-    bool
-    WaitForUpdaterStatus(int desired_state, long timeout_millis);
+    bool WaitForUpdaterStatus(int desired_state, long timeout_millis);
 
-    std::tuple<int, std::string, int>
-    GetUpdaterStatus();
+    std::tuple<int, std::string, int> GetUpdaterStatus();
 
     /**
      * C-style static callbacks for libcurl
      */
     static size_t
-    StatusWriteCallbackIgnore(char *ptr, size_t size, size_t nmemb,
+    StatusWriteCallbackIgnore(char* ptr,
+                              size_t size,
+                              size_t nmemb,
                               void* userdata)
     {
       return size * nmemb;
     }
 
     static size_t
-    StatusWriteCallback(char *ptr, size_t size, size_t nmemb,
-                        void* userdata)
+    StatusWriteCallback(char* ptr, size_t size, size_t nmemb, void* userdata)
     {
       std::string* body = static_cast<std::string*>(userdata);
       body->append(ptr, size * nmemb);
@@ -112,8 +107,11 @@ namespace ifm3d
     }
 
     static int
-    XferInfoCallback(void* clientp, curl_off_t dltotal, curl_off_t dlnow,
-                     curl_off_t ultotal, curl_off_t ulnow)
+    XferInfoCallback(void* clientp,
+                     curl_off_t dltotal,
+                     curl_off_t dlnow,
+                     curl_off_t ultotal,
+                     curl_off_t ulnow)
     {
       ifm3d::SWUpdater::Impl* swu =
         static_cast<ifm3d::SWUpdater::Impl*>(clientp);
@@ -126,7 +124,7 @@ namespace ifm3d
           else
             {
               float percentage_complete =
-                (static_cast<float>(ulnow)/static_cast<float>(ultotal));
+                (static_cast<float>(ulnow) / static_cast<float>(ultotal));
               swu->cb_(percentage_complete, "");
             }
         }
@@ -177,8 +175,9 @@ namespace ifm3d
        * Wrapper for calling curl_easy_* APIs, and unified
        * error handling of return codes.
        */
-      template<typename F, typename... Args>
-      void Call(F f, Args... args)
+      template <typename F, typename... Args>
+      void
+      Call(F f, Args... args)
       {
         CURLcode retcode = f(this->curl_, args...);
         if (retcode != CURLE_OK)
@@ -197,7 +196,8 @@ namespace ifm3d
           }
       }
 
-      void AddHeader(const char* str)
+      void
+      AddHeader(const char* str)
       {
         this->header_list_ = curl_slist_append(this->header_list_, str);
         if (!this->header_list_)
@@ -206,7 +206,8 @@ namespace ifm3d
           }
       }
 
-      void SetHeader()
+      void
+      SetHeader()
       {
         this->Call(curl_easy_setopt, CURLOPT_HTTPHEADER, this->header_list_);
       }
@@ -264,8 +265,8 @@ ifm3d::SWUpdater::Impl::WaitForRecovery(long timeout_millis)
       if (timeout_millis > 0)
         {
           auto curr = std::chrono::system_clock::now();
-          auto elapsed =
-            std::chrono::duration_cast<std::chrono::milliseconds>(curr-start);
+          auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            curr - start);
           if (elapsed.count() > timeout_millis)
             {
               LOG(WARNING) << "Timed out waiting for recovery mode";
@@ -283,11 +284,14 @@ ifm3d::SWUpdater::Impl::RebootToProductive()
   c->Call(curl_easy_setopt, CURLOPT_URL, this->reboot_url_.c_str());
   c->Call(curl_easy_setopt, CURLOPT_POST, true);
   c->Call(curl_easy_setopt, CURLOPT_POSTFIELDSIZE, 0);
-  c->Call(curl_easy_setopt, CURLOPT_WRITEFUNCTION,
+  c->Call(curl_easy_setopt,
+          CURLOPT_WRITEFUNCTION,
           &ifm3d::SWUpdater::Impl::StatusWriteCallbackIgnore);
-  c->Call(curl_easy_setopt, CURLOPT_CONNECTTIMEOUT,
+  c->Call(curl_easy_setopt,
+          CURLOPT_CONNECTTIMEOUT,
           ifm3d::DEFAULT_CURL_CONNECT_TIMEOUT);
-  c->Call(curl_easy_setopt, CURLOPT_TIMEOUT,
+  c->Call(curl_easy_setopt,
+          CURLOPT_TIMEOUT,
           ifm3d::DEFAULT_CURL_TRANSACTION_TIMEOUT);
   c->Call(curl_easy_perform);
 }
@@ -306,8 +310,8 @@ ifm3d::SWUpdater::Impl::WaitForProductive(long timeout_millis)
       if (timeout_millis > 0)
         {
           auto curr = std::chrono::system_clock::now();
-          auto elapsed =
-            std::chrono::duration_cast<std::chrono::milliseconds>(curr-start);
+          auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            curr - start);
           if (elapsed.count() > timeout_millis)
             {
               // timeout
@@ -320,20 +324,17 @@ ifm3d::SWUpdater::Impl::WaitForProductive(long timeout_millis)
 }
 
 bool
-ifm3d::SWUpdater::Impl::FlashFirmware(
-    const std::vector<std::uint8_t>& bytes,
-    long timeout_millis)
+ifm3d::SWUpdater::Impl::FlashFirmware(const std::vector<std::uint8_t>& bytes,
+                                      long timeout_millis)
 {
   auto t_start = std::chrono::system_clock::now();
   long remaining_time = timeout_millis;
-  auto get_remaining_time =
-    [&t_start, timeout_millis]() -> long
-    {
-      auto t_now = std::chrono::system_clock::now();
-      auto elapsed =
-        std::chrono::duration_cast<std::chrono::milliseconds>(t_now - t_start);
-      return timeout_millis - static_cast<long>(elapsed.count());
-    };
+  auto get_remaining_time = [&t_start, timeout_millis]() -> long {
+    auto t_now = std::chrono::system_clock::now();
+    auto elapsed =
+      std::chrono::duration_cast<std::chrono::milliseconds>(t_now - t_start);
+    return timeout_millis - static_cast<long>(elapsed.count());
+  };
 
   // Firmware updater must be in `idle` status prior to starting a firmware
   // upgrade. In some cases (firmware was flashed but the camera was not
@@ -367,7 +368,6 @@ ifm3d::SWUpdater::Impl::FlashFirmware(
   return this->WaitForUpdaterStatus(SWUPDATER_STATUS_SUCCESS, remaining_time);
 }
 
-
 //-------------------------------------
 // "Private" helpers
 //-------------------------------------
@@ -377,26 +377,28 @@ ifm3d::SWUpdater::Impl::CheckRecovery()
   auto c = std::make_unique<ifm3d::SWUpdater::Impl::CURLTransaction>();
   c->Call(curl_easy_setopt, CURLOPT_URL, this->check_recovery_url_.c_str());
   c->Call(curl_easy_setopt, CURLOPT_NOBODY, true);
-  c->Call(curl_easy_setopt, CURLOPT_CONNECTTIMEOUT,
+  c->Call(curl_easy_setopt,
+          CURLOPT_CONNECTTIMEOUT,
           ifm3d::DEFAULT_CURL_CONNECT_TIMEOUT);
-  c->Call(curl_easy_setopt, CURLOPT_TIMEOUT,
+  c->Call(curl_easy_setopt,
+          CURLOPT_TIMEOUT,
           ifm3d::DEFAULT_CURL_TRANSACTION_TIMEOUT);
 
   long status_code;
   try
-  {
-    c->Call(curl_easy_perform);
-    c->Call(curl_easy_getinfo, CURLINFO_RESPONSE_CODE, &status_code);
-  }
-  catch(const ifm3d::error_t& e)
-  {
-    if (e.code() == IFM3D_RECOVERY_CONNECTION_ERROR ||
-        e.code() == IFM3D_CURL_TIMEOUT)
-      {
-        return false;
-      }
-    throw;
-  }
+    {
+      c->Call(curl_easy_perform);
+      c->Call(curl_easy_getinfo, CURLINFO_RESPONSE_CODE, &status_code);
+    }
+  catch (const ifm3d::error_t& e)
+    {
+      if (e.code() == IFM3D_RECOVERY_CONNECTION_ERROR ||
+          e.code() == IFM3D_CURL_TIMEOUT)
+        {
+          return false;
+        }
+      throw;
+    }
 
   return status_code == 200;
 }
@@ -410,7 +412,7 @@ ifm3d::SWUpdater::Impl::CheckProductive()
         {
           return true;
         }
-     }
+    }
   catch (const ifm3d::error_t& e)
     {
       // Rethrow unless the code is one that indicates the camera is not
@@ -426,9 +428,8 @@ ifm3d::SWUpdater::Impl::CheckProductive()
 }
 
 void
-ifm3d::SWUpdater::Impl::UploadFirmware(
-    const std::vector<std::uint8_t>& bytes,
-    long timeout_millis)
+ifm3d::SWUpdater::Impl::UploadFirmware(const std::vector<std::uint8_t>& bytes,
+                                       long timeout_millis)
 {
   auto c = std::make_unique<ifm3d::SWUpdater::Impl::CURLTransaction>();
   c->AddHeader(SWUPDATER_CONTENT_TYPE_HEADER.c_str());
@@ -436,19 +437,23 @@ ifm3d::SWUpdater::Impl::UploadFirmware(
   c->SetHeader();
   c->Call(curl_easy_setopt, CURLOPT_URL, this->upload_url_.c_str());
   c->Call(curl_easy_setopt, CURLOPT_POST, 1);
-  c->Call(curl_easy_setopt, CURLOPT_POSTFIELDSIZE,
+  c->Call(curl_easy_setopt,
+          CURLOPT_POSTFIELDSIZE,
           static_cast<long>(bytes.size()));
   c->Call(curl_easy_setopt, CURLOPT_POSTFIELDS, bytes.data());
-  c->Call(curl_easy_setopt, CURLOPT_WRITEFUNCTION,
+  c->Call(curl_easy_setopt,
+          CURLOPT_WRITEFUNCTION,
           &ifm3d::SWUpdater::Impl::StatusWriteCallbackIgnore);
-  c->Call(curl_easy_setopt, CURLOPT_CONNECTTIMEOUT,
+  c->Call(curl_easy_setopt,
+          CURLOPT_CONNECTTIMEOUT,
           ifm3d::DEFAULT_CURL_CONNECT_TIMEOUT);
   c->Call(curl_easy_setopt, CURLOPT_TIMEOUT_MS, timeout_millis);
 
   // Workaround -- device does not close the connection after the firmware has
   // been transferred. Register an xfer callback and terminate the transaction
   // after all the data has been sent.
-  c->Call(curl_easy_setopt, CURLOPT_XFERINFOFUNCTION,
+  c->Call(curl_easy_setopt,
+          CURLOPT_XFERINFOFUNCTION,
           &ifm3d::SWUpdater::Impl::XferInfoCallback);
   c->Call(curl_easy_setopt, CURLOPT_XFERINFODATA, this);
   c->Call(curl_easy_setopt, CURLOPT_NOPROGRESS, 0);
@@ -459,7 +464,7 @@ ifm3d::SWUpdater::Impl::UploadFirmware(
     {
       c->Call(curl_easy_perform);
     }
-  catch(const ifm3d::error_t& e)
+  catch (const ifm3d::error_t& e)
     {
       if (e.code() != IFM3D_CURL_ABORTED)
         {
@@ -478,8 +483,7 @@ ifm3d::SWUpdater::Impl::WaitForUpdaterStatus(int desired_status,
 
   if (timeout_millis < 0)
     {
-      std::tie(status_id, std::ignore, std::ignore) =
-        this->GetUpdaterStatus();
+      std::tie(status_id, std::ignore, std::ignore) = this->GetUpdaterStatus();
       return status_id == desired_status;
     }
 
@@ -489,8 +493,8 @@ ifm3d::SWUpdater::Impl::WaitForUpdaterStatus(int desired_status,
       if (timeout_millis > 0)
         {
           auto curr = std::chrono::system_clock::now();
-          auto elapsed =
-            std::chrono::duration_cast<std::chrono::milliseconds>(curr-start);
+          auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            curr - start);
           if (elapsed.count() > timeout_millis)
             {
               // timeout
@@ -498,7 +502,7 @@ ifm3d::SWUpdater::Impl::WaitForUpdaterStatus(int desired_status,
                            << desired_status;
               return false;
             }
-         }
+        }
 
       std::tie(status_id, status_message, status_error) =
         this->GetUpdaterStatus();
@@ -509,8 +513,8 @@ ifm3d::SWUpdater::Impl::WaitForUpdaterStatus(int desired_status,
             {
               this->cb_(1.0, status_message);
             }
-          LOG(INFO) << "[" << status_id << "][" << status_error << "]: "
-                    << status_message;
+          LOG(INFO) << "[" << status_id << "][" << status_error
+                    << "]: " << status_message;
         }
 
       if (status_id == SWUPDATER_STATUS_FAILURE)
@@ -524,7 +528,8 @@ ifm3d::SWUpdater::Impl::WaitForUpdaterStatus(int desired_status,
         }
 
       std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    } while (status_id != desired_status);
+    }
+  while (status_id != desired_status);
 
   return true;
 }
@@ -544,9 +549,11 @@ ifm3d::SWUpdater::Impl::GetUpdaterStatus()
           CURLOPT_WRITEFUNCTION,
           &ifm3d::SWUpdater::Impl::StatusWriteCallback);
   c->Call(curl_easy_setopt, CURLOPT_WRITEDATA, &status_string);
-  c->Call(curl_easy_setopt, CURLOPT_CONNECTTIMEOUT,
+  c->Call(curl_easy_setopt,
+          CURLOPT_CONNECTTIMEOUT,
           ifm3d::DEFAULT_CURL_CONNECT_TIMEOUT);
-  c->Call(curl_easy_setopt, CURLOPT_TIMEOUT,
+  c->Call(curl_easy_setopt,
+          CURLOPT_TIMEOUT,
           ifm3d::DEFAULT_CURL_TRANSACTION_TIMEOUT);
   c->Call(curl_easy_perform);
 
@@ -560,4 +567,3 @@ ifm3d::SWUpdater::Impl::GetUpdaterStatus()
 }
 
 #endif // __IFM3D_SWUPDATER_SWUPDATER_IMPL_H__
-

--- a/modules/swupdater/test/ifm3d-swupdater-testrunner.cpp
+++ b/modules/swupdater/test/ifm3d-swupdater-testrunner.cpp
@@ -1,7 +1,8 @@
 #include <ifm3d/swupdater.h>
 #include <gtest/gtest.h>
 
-int main(int argc, char **argv)
+int
+main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/modules/swupdater/test/ifm3d-swupdater-tests.cpp
+++ b/modules/swupdater/test/ifm3d-swupdater-tests.cpp
@@ -13,7 +13,8 @@ class SWUpdater : public ::testing::Test
 protected:
   SWUpdater() = default;
 
-  void TearDown() override
+  void
+  TearDown() override
   {
     // Give the camera some extra time to 'settle' before moving to the next
     // test. In pratice, the camera needs a little bit of settle time after
@@ -74,4 +75,3 @@ TEST_F(SWUpdater, FlashEmptyFile)
   swu->RebootToProductive();
   EXPECT_TRUE(swu->WaitForProductive(60000));
 }
-

--- a/modules/tools/include/ifm3d/tools.h
+++ b/modules/tools/include/ifm3d/tools.h
@@ -36,13 +36,13 @@
 #include <ifm3d/tools/trace_app.h>
 
 #if defined(BUILD_MODULE_FRAMEGRABBER)
-#include <ifm3d/tools/fg/schema_app.h>
-#include <ifm3d/tools/fg/hz_app.h>
-#include <ifm3d/tools/fg/jitter_app.h>
+#  include <ifm3d/tools/fg/schema_app.h>
+#  include <ifm3d/tools/fg/hz_app.h>
+#  include <ifm3d/tools/fg/jitter_app.h>
 #endif
 
 #if defined(BUILD_MODULE_SWUPDATER)
-#include <ifm3d/tools/swupdater/swupdate_app.h>
+#  include <ifm3d/tools/swupdater/swupdate_app.h>
 #endif
 
 #endif // __IFM3D_TOOLS_H__

--- a/modules/tools/include/ifm3d/tools/app_types_app.h
+++ b/modules/tools/include/ifm3d/tools/app_types_app.h
@@ -30,7 +30,8 @@ namespace ifm3d
   class AppTypesApp : public ifm3d::CmdLineApp
   {
   public:
-    AppTypesApp(int argc, const char **argv,
+    AppTypesApp(int argc,
+                const char** argv,
                 const std::string& name = "app-types");
     int Run();
   }; // end: class AppTypeApp

--- a/modules/tools/include/ifm3d/tools/cmdline_app.h
+++ b/modules/tools/include/ifm3d/tools/cmdline_app.h
@@ -39,7 +39,8 @@ namespace ifm3d
   public:
     using Ptr = std::shared_ptr<CmdLineApp>;
 
-    CmdLineApp(int argc, const char **argv,
+    CmdLineApp(int argc,
+               const char** argv,
                const std::string& name = "version");
     virtual ~CmdLineApp() = default;
 

--- a/modules/tools/include/ifm3d/tools/config_app.h
+++ b/modules/tools/include/ifm3d/tools/config_app.h
@@ -34,7 +34,7 @@ namespace ifm3d
   class ConfigApp : public ifm3d::CmdLineApp
   {
   public:
-    ConfigApp(int argc, const char **argv, const std::string& name = "config");
+    ConfigApp(int argc, const char** argv, const std::string& name = "config");
     int Run();
   }; // end: class ConfigApp
 

--- a/modules/tools/include/ifm3d/tools/cp_app.h
+++ b/modules/tools/include/ifm3d/tools/cp_app.h
@@ -30,7 +30,7 @@ namespace ifm3d
   class CpApp : public ifm3d::CmdLineApp
   {
   public:
-    CpApp(int argc, const char **argv, const std::string& name = "cp");
+    CpApp(int argc, const char** argv, const std::string& name = "cp");
     int Run();
   }; // end: class CpApp
 

--- a/modules/tools/include/ifm3d/tools/dump_app.h
+++ b/modules/tools/include/ifm3d/tools/dump_app.h
@@ -32,7 +32,7 @@ namespace ifm3d
   class DumpApp : public ifm3d::CmdLineApp
   {
   public:
-    DumpApp(int argc, const char **argv, const std::string& name = "dump");
+    DumpApp(int argc, const char** argv, const std::string& name = "dump");
     int Run();
   }; // end: class DumpApp
 

--- a/modules/tools/include/ifm3d/tools/export_app.h
+++ b/modules/tools/include/ifm3d/tools/export_app.h
@@ -34,7 +34,7 @@ namespace ifm3d
   class ExportApp : public ifm3d::CmdLineApp
   {
   public:
-    ExportApp(int argc, const char **argv, const std::string& name = "export");
+    ExportApp(int argc, const char** argv, const std::string& name = "export");
     int Run();
   }; // end: class ExportApp
 

--- a/modules/tools/include/ifm3d/tools/fg/hz_app.h
+++ b/modules/tools/include/ifm3d/tools/fg/hz_app.h
@@ -30,7 +30,7 @@ namespace ifm3d
   class HzApp : public ifm3d::CmdLineApp
   {
   public:
-    HzApp(int argc, const char **argv, const std::string& name = "hz");
+    HzApp(int argc, const char** argv, const std::string& name = "hz");
     int Run();
   };
 

--- a/modules/tools/include/ifm3d/tools/fg/jitter_app.h
+++ b/modules/tools/include/ifm3d/tools/fg/jitter_app.h
@@ -29,7 +29,7 @@ namespace ifm3d
   class JitterApp : public ifm3d::CmdLineApp
   {
   public:
-    JitterApp(int argc, const char **argv, const std::string& name = "jitter");
+    JitterApp(int argc, const char** argv, const std::string& name = "jitter");
     int Run();
   };
 

--- a/modules/tools/include/ifm3d/tools/fg/schema_app.h
+++ b/modules/tools/include/ifm3d/tools/fg/schema_app.h
@@ -30,8 +30,7 @@ namespace ifm3d
   class SchemaApp : public ifm3d::CmdLineApp
   {
   public:
-    SchemaApp(int argc, const char **argv,
-              const std::string& name = "schema");
+    SchemaApp(int argc, const char** argv, const std::string& name = "schema");
     int Run();
   };
 

--- a/modules/tools/include/ifm3d/tools/imager_types_app.h
+++ b/modules/tools/include/ifm3d/tools/imager_types_app.h
@@ -30,7 +30,8 @@ namespace ifm3d
   class ImagerTypesApp : public ifm3d::CmdLineApp
   {
   public:
-    ImagerTypesApp(int argc, const char **argv,
+    ImagerTypesApp(int argc,
+                   const char** argv,
                    const std::string& name = "imager-types");
     int Run();
   }; // end: class ImagerTypesApp

--- a/modules/tools/include/ifm3d/tools/import_app.h
+++ b/modules/tools/include/ifm3d/tools/import_app.h
@@ -33,7 +33,7 @@ namespace ifm3d
   class ImportApp : public ifm3d::CmdLineApp
   {
   public:
-    ImportApp(int argc, const char **argv, const std::string& name = "import");
+    ImportApp(int argc, const char** argv, const std::string& name = "import");
     int Run();
   }; // end: class ImportApp
 

--- a/modules/tools/include/ifm3d/tools/ls_app.h
+++ b/modules/tools/include/ifm3d/tools/ls_app.h
@@ -30,7 +30,7 @@ namespace ifm3d
   class LsApp : public ifm3d::CmdLineApp
   {
   public:
-    LsApp(int argc, const char **argv, const std::string& name = "ls");
+    LsApp(int argc, const char** argv, const std::string& name = "ls");
     int Run();
   }; // end: class LsApp
 } // end: namespace ifm3d

--- a/modules/tools/include/ifm3d/tools/make_app.h
+++ b/modules/tools/include/ifm3d/tools/make_app.h
@@ -37,7 +37,7 @@ namespace ifm3d
    * @return A smart pointer to an application implementing the passed in
    *         subcommand.
    */
-  ifm3d::CmdLineApp::Ptr make_app(int argc, const char **argv);
+  ifm3d::CmdLineApp::Ptr make_app(int argc, const char** argv);
 
 } // end: namespace ifm3d
 

--- a/modules/tools/include/ifm3d/tools/passwd_app.h
+++ b/modules/tools/include/ifm3d/tools/passwd_app.h
@@ -30,7 +30,9 @@ namespace ifm3d
   class PasswdApp : public ifm3d::CmdLineApp
   {
   public:
-	  PasswdApp(int argc, const char **argv, const std::string& name = "password");
+    PasswdApp(int argc,
+              const char** argv,
+              const std::string& name = "password");
     int Run();
   }; // end: class Passwd
 } // end: namespace ifm3d

--- a/modules/tools/include/ifm3d/tools/reboot_app.h
+++ b/modules/tools/include/ifm3d/tools/reboot_app.h
@@ -30,7 +30,7 @@ namespace ifm3d
   class RebootApp : public ifm3d::CmdLineApp
   {
   public:
-    RebootApp(int argc, const char **argv, const std::string& name = "reboot");
+    RebootApp(int argc, const char** argv, const std::string& name = "reboot");
     int Run();
   }; // end: class RebootApp
 } // end: namespace ifm3d

--- a/modules/tools/include/ifm3d/tools/reset_app.h
+++ b/modules/tools/include/ifm3d/tools/reset_app.h
@@ -30,7 +30,7 @@ namespace ifm3d
   class ResetApp : public ifm3d::CmdLineApp
   {
   public:
-    ResetApp(int argc, const char **argv, const std::string& name = "reset");
+    ResetApp(int argc, const char** argv, const std::string& name = "reset");
     int Run();
   }; // end: class ResetApp
 

--- a/modules/tools/include/ifm3d/tools/rm_app.h
+++ b/modules/tools/include/ifm3d/tools/rm_app.h
@@ -30,7 +30,7 @@ namespace ifm3d
   class RmApp : public ifm3d::CmdLineApp
   {
   public:
-    RmApp(int argc, const char **argv, const std::string& name = "rm");
+    RmApp(int argc, const char** argv, const std::string& name = "rm");
     int Run();
   }; // end: class RmApp
 

--- a/modules/tools/include/ifm3d/tools/swupdate_app.h
+++ b/modules/tools/include/ifm3d/tools/swupdate_app.h
@@ -30,14 +30,15 @@ namespace ifm3d
   class SwupdateApp : public ifm3d::CmdLineApp
   {
   public:
-    SwupdateApp(int argc, const char **argv,
+    SwupdateApp(int argc,
+                const char** argv,
                 const std::string& name = "swupdate");
     int Run();
 
   private:
-   /**
-    * Check if the device is in recovery mode
-    */
+    /**
+     * Check if the device is in recovery mode
+     */
     void checkRecovery();
 
     /**

--- a/modules/tools/include/ifm3d/tools/swupdater/swupdate_app.h
+++ b/modules/tools/include/ifm3d/tools/swupdater/swupdate_app.h
@@ -29,7 +29,8 @@ namespace ifm3d
   class SWUpdateApp : public ifm3d::CmdLineApp
   {
   public:
-    SWUpdateApp(int argc, const char **argv,
+    SWUpdateApp(int argc,
+                const char** argv,
                 const std::string& name = "swupdate");
     int Run();
   };

--- a/modules/tools/include/ifm3d/tools/time_app.h
+++ b/modules/tools/include/ifm3d/tools/time_app.h
@@ -30,7 +30,7 @@ namespace ifm3d
   class TimeApp : public ifm3d::CmdLineApp
   {
   public:
-    TimeApp(int argc, const char **argv, const std::string& name = "time");
+    TimeApp(int argc, const char** argv, const std::string& name = "time");
     int Run();
 
   }; // end: class TimeApp

--- a/modules/tools/include/ifm3d/tools/tools_export.h
+++ b/modules/tools/include/ifm3d/tools/tools_export.h
@@ -7,9 +7,8 @@
 #  ifdef IFM3D_TOOLS_DLL_BUILD
 #    define IFM3D_TOOLS_EXPORT __declspec(dllexport)
 #  else
-#     define IFM3D_TOOLS_EXPORT __declspec(dllimport)
+#    define IFM3D_TOOLS_EXPORT __declspec(dllimport)
 #  endif
 #endif
 
 #endif /* IFM3D_TOOLS_EXPORT_HPP */
-

--- a/modules/tools/include/ifm3d/tools/trace_app.h
+++ b/modules/tools/include/ifm3d/tools/trace_app.h
@@ -24,13 +24,13 @@
 namespace ifm3d
 {
   /**
-   * Concrete implementation of the `trace` subcommand to the `ifm3d` command-line
-   * utility.
+   * Concrete implementation of the `trace` subcommand to the `ifm3d`
+   * command-line utility.
    */
   class TraceApp : public ifm3d::CmdLineApp
   {
   public:
-    TraceApp(int argc, const char **argv, const std::string& name = "trace");
+    TraceApp(int argc, const char** argv, const std::string& name = "trace");
     int Run();
   }; // end: class TraceApp
 } // end: namespace ifm3d

--- a/modules/tools/src/bin/ifm3d.cpp
+++ b/modules/tools/src/bin/ifm3d.cpp
@@ -19,7 +19,8 @@
 #include <exception>
 #include <iostream>
 
-int main(int argc, const char** argv)
+int
+main(int argc, const char** argv)
 {
   int err = 0;
   try

--- a/modules/tools/src/libifm3d_tools/app_types_app.cpp
+++ b/modules/tools/src/libifm3d_tools/app_types_app.cpp
@@ -20,12 +20,14 @@
 #include <ifm3d/tools/cmdline_app.h>
 #include <ifm3d/camera/camera.h>
 
-ifm3d::AppTypesApp::AppTypesApp(int argc, const char **argv,
+ifm3d::AppTypesApp::AppTypesApp(int argc,
+                                const char** argv,
                                 const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 { }
 
-int ifm3d::AppTypesApp::Run()
+int
+ifm3d::AppTypesApp::Run()
 {
   if (this->vm_.count("help"))
     {

--- a/modules/tools/src/libifm3d_tools/cmdline_app.cpp
+++ b/modules/tools/src/libifm3d_tools/cmdline_app.cpp
@@ -28,6 +28,7 @@ ifm3d::CmdLineApp::CmdLineApp(int argc, const char **argv,
   : global_opts_("global options"),
     local_opts_(name + " options")
 {
+  // clang-format off
   this->global_opts_.add_options()
     ("help,h", "Produce this help message and exit")
     ("ip", po::value<std::string>()->default_value(ifm3d::DEFAULT_IP),
@@ -43,6 +44,7 @@ ifm3d::CmdLineApp::CmdLineApp(int argc, const char **argv,
   hidden_opts.add_options()
     ("command", po::value<std::string>()->default_value(name),
      "ifm3d Sub-command to execute");
+  // clang-format on
 
   po::options_description all_opts;
   all_opts.add(this->global_opts_).add(hidden_opts);

--- a/modules/tools/src/libifm3d_tools/cmdline_app.cpp
+++ b/modules/tools/src/libifm3d_tools/cmdline_app.cpp
@@ -23,7 +23,8 @@
 
 namespace po = boost::program_options;
 
-ifm3d::CmdLineApp::CmdLineApp(int argc, const char **argv,
+ifm3d::CmdLineApp::CmdLineApp(int argc,
+                              const char** argv,
                               const std::string& name)
   : global_opts_("global options"),
     local_opts_(name + " options")
@@ -52,9 +53,12 @@ ifm3d::CmdLineApp::CmdLineApp(int argc, const char **argv,
   po::positional_options_description p;
   p.add("command", 1);
 
-  po::store(po::command_line_parser(argc, argv).
-            options(all_opts).positional(p).
-            allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(all_opts)
+              .positional(p)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 
   this->ip_ = this->vm_["ip"].as<std::string>();
@@ -75,11 +79,9 @@ void
 ifm3d::CmdLineApp::_LocalHelp()
 {
   std::string cmd = this->vm_["command"].as<std::string>();
-  std::cout << "usage: " << IFM3D_LIBRARY_NAME
-            << " [<global options>] "
-            << cmd
-            << " [<" << cmd << " options>]"
-            << std::endl << std::endl;
+  std::cout << "usage: " << IFM3D_LIBRARY_NAME << " [<global options>] " << cmd
+            << " [<" << cmd << " options>]" << std::endl
+            << std::endl;
   std::cout << this->global_opts_ << std::endl;
   std::cout << this->local_opts_ << std::endl;
 }
@@ -169,15 +171,14 @@ https://github.com/ifm/ifm3d/issues
       )";
 
   ifm3d::version(&major, &minor, &patch);
-  std::cout << IFM3D_LIBRARY_NAME
-            << ": version=" << major << "."
-            << minor << "." << patch << std::endl;
+  std::cout << IFM3D_LIBRARY_NAME << ": version=" << major << "." << minor
+            << "." << patch << std::endl;
 
   if (this->vm_.count("help"))
     {
       std::cout << "usage: " << IFM3D_LIBRARY_NAME
-                << " [<global options>] <command> [<args>]"
-                << std::endl << std::endl;
+                << " [<global options>] <command> [<args>]" << std::endl
+                << std::endl;
       std::cout << this->global_opts_ << std::endl;
       std::cout << help_msg << std::endl;
     }

--- a/modules/tools/src/libifm3d_tools/config_app.cpp
+++ b/modules/tools/src/libifm3d_tools/config_app.cpp
@@ -30,9 +30,11 @@ ifm3d::ConfigApp::ConfigApp(int argc, const char **argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
   this->local_opts_.add_options()
     ("file", po::value<std::string>()->default_value("-"),
      "Input JSON configuration file (defaults to stdin)");
+  // clang-format on
 
   po::store(po::command_line_parser(argc, argv).
             options(this->local_opts_).allow_unregistered().run(), this->vm_);

--- a/modules/tools/src/libifm3d_tools/config_app.cpp
+++ b/modules/tools/src/libifm3d_tools/config_app.cpp
@@ -26,7 +26,8 @@
 
 namespace po = boost::program_options;
 
-ifm3d::ConfigApp::ConfigApp(int argc, const char **argv,
+ifm3d::ConfigApp::ConfigApp(int argc,
+                            const char** argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
@@ -36,12 +37,16 @@ ifm3d::ConfigApp::ConfigApp(int argc, const char **argv,
      "Input JSON configuration file (defaults to stdin)");
   // clang-format on
 
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 
-int ifm3d::ConfigApp::Run()
+int
+ifm3d::ConfigApp::Run()
 {
   if (this->vm_.count("help"))
     {
@@ -66,7 +71,7 @@ int ifm3d::ConfigApp::Run()
   else
     {
       std::ifstream ifs(infile, std::ios::in);
-      if (! ifs)
+      if (!ifs)
         {
           std::cerr << "Could not parse file: " << infile << std::endl;
           throw ifm3d::error_t(IFM3D_IO_ERROR);

--- a/modules/tools/src/libifm3d_tools/cp_app.cpp
+++ b/modules/tools/src/libifm3d_tools/cp_app.cpp
@@ -23,8 +23,7 @@
 
 namespace po = boost::program_options;
 
-ifm3d::CpApp::CpApp(int argc, const char **argv,
-                    const std::string& name)
+ifm3d::CpApp::CpApp(int argc, const char** argv, const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
   // clang-format off
@@ -34,8 +33,11 @@ ifm3d::CpApp::CpApp(int argc, const char **argv,
      "Index of source application to copy");
   // clang-format on
 
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 

--- a/modules/tools/src/libifm3d_tools/cp_app.cpp
+++ b/modules/tools/src/libifm3d_tools/cp_app.cpp
@@ -27,10 +27,12 @@ ifm3d::CpApp::CpApp(int argc, const char **argv,
                     const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
   this->local_opts_.add_options()
     ("index",
      po::value<int>()->default_value(-1),
      "Index of source application to copy");
+  // clang-format on
 
   po::store(po::command_line_parser(argc, argv).
             options(this->local_opts_).allow_unregistered().run(), this->vm_);

--- a/modules/tools/src/libifm3d_tools/dump_app.cpp
+++ b/modules/tools/src/libifm3d_tools/dump_app.cpp
@@ -19,12 +19,12 @@
 #include <string>
 #include <ifm3d/tools/cmdline_app.h>
 
-ifm3d::DumpApp::DumpApp(int argc, const char **argv,
-                        const std::string& name)
+ifm3d::DumpApp::DumpApp(int argc, const char** argv, const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 { }
 
-int ifm3d::DumpApp::Run()
+int
+ifm3d::DumpApp::Run()
 {
   if (this->vm_.count("help"))
     {

--- a/modules/tools/src/libifm3d_tools/export_app.cpp
+++ b/modules/tools/src/libifm3d_tools/export_app.cpp
@@ -26,7 +26,8 @@
 
 namespace po = boost::program_options;
 
-ifm3d::ExportApp::ExportApp(int argc, const char **argv,
+ifm3d::ExportApp::ExportApp(int argc,
+                            const char** argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
@@ -39,12 +40,16 @@ ifm3d::ExportApp::ExportApp(int argc, const char **argv,
      "If provided, this specifies the index of an application to export");
   // clang-format on
 
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 
-int ifm3d::ExportApp::Run()
+int
+ifm3d::ExportApp::Run()
 {
   if (this->vm_.count("help"))
     {
@@ -67,12 +72,12 @@ int ifm3d::ExportApp::Run()
   std::string outfile = this->vm_["file"].as<std::string>();
   if (outfile == "-")
     {
-      std::cout.write(reinterpret_cast<char *>(bytes.data()), bytes.size());
+      std::cout.write(reinterpret_cast<char*>(bytes.data()), bytes.size());
     }
   else
     {
-      std::ofstream(outfile, std::ios::binary).
-        write(reinterpret_cast<char *>(bytes.data()), bytes.size());
+      std::ofstream(outfile, std::ios::binary)
+        .write(reinterpret_cast<char*>(bytes.data()), bytes.size());
     }
 
   return 0;

--- a/modules/tools/src/libifm3d_tools/export_app.cpp
+++ b/modules/tools/src/libifm3d_tools/export_app.cpp
@@ -30,12 +30,14 @@ ifm3d::ExportApp::ExportApp(int argc, const char **argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
   this->local_opts_.add_options()
     ("file", po::value<std::string>()->default_value("-"),
      "Output file, defaults to `stdout' (good for piping to other tools)")
     ("index",
      po::value<int>()->default_value(-1),
      "If provided, this specifies the index of an application to export");
+  // clang-format on
 
   po::store(po::command_line_parser(argc, argv).
             options(this->local_opts_).allow_unregistered().run(), this->vm_);

--- a/modules/tools/src/libifm3d_tools/fg/hz_app.cpp
+++ b/modules/tools/src/libifm3d_tools/fg/hz_app.cpp
@@ -31,34 +31,34 @@
 class MyBuff : public ifm3d::ByteBuffer<MyBuff>
 {
 public:
-  MyBuff() : ifm3d::ByteBuffer<MyBuff>()
+  MyBuff() : ifm3d::ByteBuffer<MyBuff>() { }
+
+  template <typename T>
+  void
+  ImCreate(ifm3d::image_chunk im,
+           std::uint32_t fmt,
+           std::size_t idx,
+           std::uint32_t width,
+           std::uint32_t height,
+           int nchan,
+           std::uint32_t npts,
+           const std::vector<std::uint8_t>& bytes)
   { }
 
   template <typename T>
-  void ImCreate(ifm3d::image_chunk im,
-                std::uint32_t fmt,
-                std::size_t idx,
-                std::uint32_t width,
-                std::uint32_t height,
-                int nchan,
-                std::uint32_t npts,
-                const std::vector<std::uint8_t>& bytes)
-  { }
-
-  template <typename T>
-  void CloudCreate(std::uint32_t fmt,
-                   std::size_t xidx,
-                   std::size_t yidx,
-                   std::size_t zidx,
-                   std::uint32_t width,
-                   std::uint32_t height,
-                   std::uint32_t npts,
-                   const std::vector<std::uint8_t>& bytes)
+  void
+  CloudCreate(std::uint32_t fmt,
+              std::size_t xidx,
+              std::size_t yidx,
+              std::size_t zidx,
+              std::uint32_t width,
+              std::uint32_t height,
+              std::uint32_t npts,
+              const std::vector<std::uint8_t>& bytes)
   { }
 };
 
-ifm3d::HzApp::HzApp(int argc, const char **argv,
-                    const std::string& name)
+ifm3d::HzApp::HzApp(int argc, const char** argv, const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
   // clang-format off
@@ -73,12 +73,16 @@ ifm3d::HzApp::HzApp(int argc, const char **argv,
      "Software Trigger the FrameGrabber");
   // clang-format on
 
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 
-int ifm3d::HzApp::Run()
+int
+ifm3d::HzApp::Run()
 {
   if (this->vm_.count("help"))
     {
@@ -100,7 +104,7 @@ int ifm3d::HzApp::Run()
   std::vector<double> stats;
 
   auto fg = std::make_shared<ifm3d::FrameGrabber>(this->cam_);
-  auto buff = std::make_shared<ifm3d::ByteBuffer<MyBuff> >();
+  auto buff = std::make_shared<ifm3d::ByteBuffer<MyBuff>>();
 
   for (int i = 0; i < nruns; i++)
     {
@@ -112,7 +116,7 @@ int ifm3d::HzApp::Run()
               fg->SWTrigger();
             }
 
-          if (! fg->WaitForFrame(buff.get(), 1000))
+          if (!fg->WaitForFrame(buff.get(), 1000))
             {
               std::cerr << "Timeout waiting for camera!" << std::endl;
               return -1;
@@ -130,18 +134,17 @@ int ifm3d::HzApp::Run()
 
       if (sz % 2 == 0)
         {
-          median = (stats.at(sz/2-1)+stats.at(sz/2))/2;
+          median = (stats.at(sz / 2 - 1) + stats.at(sz / 2)) / 2;
         }
       else
         {
-          median = stats.at(sz/2);
+          median = stats.at(sz / 2);
         }
 
-      std::cout << "FrameGrabber running at: "
-                << nframes / median << " Hz"
+      std::cout << "FrameGrabber running at: " << nframes / median << " Hz"
                 << std::endl
-                << nframes << " frames captured, over "
-                << nruns << " runs" << std::endl;
+                << nframes << " frames captured, over " << nruns << " runs"
+                << std::endl;
     }
 
   return 0;

--- a/modules/tools/src/libifm3d_tools/fg/hz_app.cpp
+++ b/modules/tools/src/libifm3d_tools/fg/hz_app.cpp
@@ -61,6 +61,7 @@ ifm3d::HzApp::HzApp(int argc, const char **argv,
                     const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
   this->local_opts_.add_options()
     ("nframes",
      po::value<int>()->default_value(10),
@@ -70,6 +71,7 @@ ifm3d::HzApp::HzApp(int argc, const char **argv,
      "Number of runs to compute summary statistics over")
     ("sw",
      "Software Trigger the FrameGrabber");
+  // clang-format on
 
   po::store(po::command_line_parser(argc, argv).
             options(this->local_opts_).allow_unregistered().run(), this->vm_);

--- a/modules/tools/src/libifm3d_tools/fg/jitter_app.cpp
+++ b/modules/tools/src/libifm3d_tools/fg/jitter_app.cpp
@@ -35,11 +35,11 @@
 #include <ifm3d/fg.h>
 
 #if defined(BUILD_MODULE_IMAGE)
-#include <ifm3d/image.h>
+#  include <ifm3d/image.h>
 #endif
 
 #if defined(BUILD_MODULE_OPENCV)
-#include <ifm3d/opencv.h>
+#  include <ifm3d/opencv.h>
 #endif
 
 // Make sure we use a steady_clock -- prefer the high_resolution_clock
@@ -53,33 +53,35 @@ using Clock_t = std::conditional<std::chrono::high_resolution_clock::is_steady,
 class MyBuff : public ifm3d::ByteBuffer<MyBuff>
 {
 public:
-  MyBuff() : ifm3d::ByteBuffer<MyBuff>()
+  MyBuff() : ifm3d::ByteBuffer<MyBuff>() { }
+
+  template <typename T>
+  void
+  ImCreate(ifm3d::image_chunk im,
+           std::uint32_t fmt,
+           std::size_t idx,
+           std::uint32_t width,
+           std::uint32_t height,
+           int nchan,
+           std::uint32_t npts,
+           const std::vector<std::uint8_t>& bytes)
   { }
 
   template <typename T>
-  void ImCreate(ifm3d::image_chunk im,
-                std::uint32_t fmt,
-                std::size_t idx,
-                std::uint32_t width,
-                std::uint32_t height,
-                int nchan,
-                std::uint32_t npts,
-                const std::vector<std::uint8_t>& bytes)
-  { }
-
-  template <typename T>
-  void CloudCreate(std::uint32_t fmt,
-                   std::size_t xidx,
-                   std::size_t yidx,
-                   std::size_t zidx,
-                   std::uint32_t width,
-                   std::uint32_t height,
-                   std::uint32_t npts,
-                   const std::vector<std::uint8_t>& bytes)
+  void
+  CloudCreate(std::uint32_t fmt,
+              std::size_t xidx,
+              std::size_t yidx,
+              std::size_t zidx,
+              std::uint32_t width,
+              std::uint32_t height,
+              std::uint32_t npts,
+              const std::vector<std::uint8_t>& bytes)
   { }
 };
 
-ifm3d::JitterApp::JitterApp(int argc, const char **argv,
+ifm3d::JitterApp::JitterApp(int argc,
+                            const char** argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
@@ -93,8 +95,11 @@ ifm3d::JitterApp::JitterApp(int argc, const char **argv,
      "Raw data output file, if not specified, nothing is written");
   // clang-format on
 
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 
@@ -102,7 +107,8 @@ ifm3d::JitterApp::JitterApp(int argc, const char **argv,
 // utility functions for computing summary statistics
 //
 template <typename T>
-T median(const std::vector<T>& arr)
+T
+median(const std::vector<T>& arr)
 {
   T median = 0;
   std::size_t sz = arr.size();
@@ -116,11 +122,11 @@ T median(const std::vector<T>& arr)
     {
       if (sz % 2 == 0)
         {
-          median = (arr_cp.at((sz/2)-1)+arr_cp.at(sz/2))/2.;
+          median = (arr_cp.at((sz / 2) - 1) + arr_cp.at(sz / 2)) / 2.;
         }
       else
         {
-          median = arr_cp.at(sz/2);
+          median = arr_cp.at(sz / 2);
         }
     }
 
@@ -128,7 +134,8 @@ T median(const std::vector<T>& arr)
 }
 
 template <typename T>
-std::tuple<T, T> mean_stdev(const std::vector<T>& arr)
+std::tuple<T, T>
+mean_stdev(const std::vector<T>& arr)
 {
   if (arr.size() < 1)
     {
@@ -139,16 +146,17 @@ std::tuple<T, T> mean_stdev(const std::vector<T>& arr)
   T mean = sum / arr.size();
 
   T ssd = 0;
-  std::for_each(arr.begin(), arr.end(),
-                [&](const T val) -> void
-                { ssd += ((val - mean) * (val - mean)); });
+  std::for_each(arr.begin(), arr.end(), [&](const T val) -> void {
+    ssd += ((val - mean) * (val - mean));
+  });
 
-  T stdev = std::sqrt(ssd / (arr.size()-1));
+  T stdev = std::sqrt(ssd / (arr.size() - 1));
   return std::make_tuple(mean, stdev);
 }
 
 template <typename T>
-T mad(const std::vector<T>& arr, T center)
+T
+mad(const std::vector<T>& arr, T center)
 {
   std::size_t n = arr.size();
   std::vector<T> arr_d(n);
@@ -164,13 +172,14 @@ T mad(const std::vector<T>& arr, T center)
 // Captures the timing metrics
 //
 template <typename T>
-void capture_frames(ifm3d::Camera::Ptr cam, T buff, std::vector<float>& results)
+void
+capture_frames(ifm3d::Camera::Ptr cam, T buff, std::vector<float>& results)
 {
   int nframes = results.size();
   auto fg = std::make_shared<ifm3d::FrameGrabber>(cam);
   // get one-time allocations out of the way, and, make
   // sure it doesn't get optimized away by the compiler
-  if (! fg->WaitForFrame(buff.get(), 1000))
+  if (!fg->WaitForFrame(buff.get(), 1000))
     {
       std::cerr << "Timeout waiting for first image acquisition!" << std::endl;
       return;
@@ -179,7 +188,7 @@ void capture_frames(ifm3d::Camera::Ptr cam, T buff, std::vector<float>& results)
   for (int i = 0; i < nframes; ++i)
     {
       auto t1 = Clock_t::now();
-      if (! fg->WaitForFrame(buff.get(), 1000))
+      if (!fg->WaitForFrame(buff.get(), 1000))
         {
           std::cerr << "Timeout waiting for image acquisition!" << std::endl;
           return;
@@ -194,7 +203,8 @@ void capture_frames(ifm3d::Camera::Ptr cam, T buff, std::vector<float>& results)
 //
 // here is our "main()"
 //
-int ifm3d::JitterApp::Run()
+int
+ifm3d::JitterApp::Run()
 {
   if (this->vm_.count("help"))
     {
@@ -211,7 +221,7 @@ int ifm3d::JitterApp::Run()
   //
   std::vector<float> bb_results(nframes, 0.);
   std::cout << "Capturing frame data for ifm3d::ByteBuffer..." << std::endl;
-  auto bb = std::make_shared<ifm3d::ByteBuffer<MyBuff> >();
+  auto bb = std::make_shared<ifm3d::ByteBuffer<MyBuff>>();
   capture_frames(this->cam_, bb, bb_results);
   float bb_median = median(bb_results);
   float bb_mean, bb_stdev;
@@ -256,7 +266,6 @@ int ifm3d::JitterApp::Run()
   std::cout << "Stdev:  " << oc_stdev << " ms" << std::endl;
   std::cout << "Mad:    " << oc_mad << " ms" << std::endl;
 #endif
-
 
   //
   // compute summary statistics

--- a/modules/tools/src/libifm3d_tools/fg/jitter_app.cpp
+++ b/modules/tools/src/libifm3d_tools/fg/jitter_app.cpp
@@ -83,6 +83,7 @@ ifm3d::JitterApp::JitterApp(int argc, const char **argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
   this->local_opts_.add_options()
     ("nframes",
      po::value<int>()->default_value(100),
@@ -90,6 +91,7 @@ ifm3d::JitterApp::JitterApp(int argc, const char **argv,
     ("outfile",
      po::value<std::string>()->default_value("-"),
      "Raw data output file, if not specified, nothing is written");
+  // clang-format on
 
   po::store(po::command_line_parser(argc, argv).
             options(this->local_opts_).allow_unregistered().run(), this->vm_);

--- a/modules/tools/src/libifm3d_tools/fg/schema_app.cpp
+++ b/modules/tools/src/libifm3d_tools/fg/schema_app.cpp
@@ -26,6 +26,7 @@ ifm3d::SchemaApp::SchemaApp(int argc, const char **argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
   this->local_opts_.add_options()
     ("mask",
      po::value<std::uint16_t>()->default_value(ifm3d::DEFAULT_SCHEMA_MASK),
@@ -35,6 +36,7 @@ ifm3d::SchemaApp::SchemaApp(int argc, const char **argv,
      "Mask string: e.g., 'IMG_AMP|IMG_CART'")
     ("dump",
      "Dump masking options and exit");
+  // clang-format on
 
   po::store(po::command_line_parser(argc, argv).
             options(this->local_opts_).allow_unregistered().run(), this->vm_);

--- a/modules/tools/src/libifm3d_tools/fg/schema_app.cpp
+++ b/modules/tools/src/libifm3d_tools/fg/schema_app.cpp
@@ -22,7 +22,8 @@
 #include <ifm3d/tools/cmdline_app.h>
 #include <ifm3d/fg/schema.h>
 
-ifm3d::SchemaApp::SchemaApp(int argc, const char **argv,
+ifm3d::SchemaApp::SchemaApp(int argc,
+                            const char** argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
@@ -38,12 +39,16 @@ ifm3d::SchemaApp::SchemaApp(int argc, const char **argv,
      "Dump masking options and exit");
   // clang-format on
 
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 
-int ifm3d::SchemaApp::Run()
+int
+ifm3d::SchemaApp::Run()
 {
   if (this->vm_.count("help"))
     {
@@ -54,28 +59,19 @@ int ifm3d::SchemaApp::Run()
   if (this->vm_.count("dump"))
     {
       std::cout << "Masking options:" << std::endl
-                << '\t' << "IMG_RDIS: "
-                << (int) ifm3d::IMG_RDIS << std::endl
-                << '\t' << "IMG_AMP:  "
-                << (int) ifm3d::IMG_AMP << std::endl
-                << '\t' << "IMG_RAMP: "
-                << (int) ifm3d::IMG_RAMP << std::endl
-                << '\t' << "IMG_CART: "
-                << (int) ifm3d::IMG_CART << std::endl
-                << '\t' << "IMG_UVEC: "
-                << (int) ifm3d::IMG_UVEC << std::endl
-                << '\t' << "EXP_TIME: "
-                << (int) ifm3d::EXP_TIME << std::endl
-                << '\t' << "IMG_GRAY: "
-                << (int) ifm3d::IMG_GRAY << std::endl
-                << '\t' << "ILLU_TEMP: "
-                << (int) ifm3d::ILLU_TEMP << std::endl
-                << '\t' << "INTR_CAL: "
-                << (int) ifm3d::INTR_CAL << std::endl
-                << '\t' << "INV_INTR_CAL: "
-                << (int) ifm3d::INV_INTR_CAL << std::endl
-                << '\t' << "JSON_MODEL: "
-                << (int) ifm3d::JSON_MODEL << std::endl;
+                << '\t' << "IMG_RDIS: " << (int)ifm3d::IMG_RDIS << std::endl
+                << '\t' << "IMG_AMP:  " << (int)ifm3d::IMG_AMP << std::endl
+                << '\t' << "IMG_RAMP: " << (int)ifm3d::IMG_RAMP << std::endl
+                << '\t' << "IMG_CART: " << (int)ifm3d::IMG_CART << std::endl
+                << '\t' << "IMG_UVEC: " << (int)ifm3d::IMG_UVEC << std::endl
+                << '\t' << "EXP_TIME: " << (int)ifm3d::EXP_TIME << std::endl
+                << '\t' << "IMG_GRAY: " << (int)ifm3d::IMG_GRAY << std::endl
+                << '\t' << "ILLU_TEMP: " << (int)ifm3d::ILLU_TEMP << std::endl
+                << '\t' << "INTR_CAL: " << (int)ifm3d::INTR_CAL << std::endl
+                << '\t' << "INV_INTR_CAL: " << (int)ifm3d::INV_INTR_CAL
+                << std::endl
+                << '\t' << "JSON_MODEL: " << (int)ifm3d::JSON_MODEL
+                << std::endl;
 
       return 0;
     }
@@ -91,15 +87,13 @@ int ifm3d::SchemaApp::Run()
       mask = ifm3d::schema_mask_from_string(mask_str);
     }
 
-  std::cout << "mask=" << (int) mask
-            << ", str=" << mask_str
-            << std::endl << "---" << std::endl
+  std::cout << "mask=" << (int)mask << ", str=" << mask_str << std::endl
+            << "---" << std::endl
             << "PCIC (O3D-compatible): " << std::endl
-            << ifm3d::make_schema(mask)
-            << std::endl << "---" << std::endl
+            << ifm3d::make_schema(mask) << std::endl
+            << "---" << std::endl
             << "XML-RPC (O3X-compatible): " << std::endl
-            << ifm3d::make_o3x_json_from_mask(mask)
-            << std::endl;
+            << ifm3d::make_o3x_json_from_mask(mask) << std::endl;
 
   return 0;
 }

--- a/modules/tools/src/libifm3d_tools/imager_types_app.cpp
+++ b/modules/tools/src/libifm3d_tools/imager_types_app.cpp
@@ -20,12 +20,14 @@
 #include <ifm3d/tools/cmdline_app.h>
 #include <ifm3d/camera/camera.h>
 
-ifm3d::ImagerTypesApp::ImagerTypesApp(int argc, const char **argv,
+ifm3d::ImagerTypesApp::ImagerTypesApp(int argc,
+                                      const char** argv,
                                       const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 { }
 
-int ifm3d::ImagerTypesApp::Run()
+int
+ifm3d::ImagerTypesApp::Run()
 {
   if (this->vm_.count("help"))
     {

--- a/modules/tools/src/libifm3d_tools/import_app.cpp
+++ b/modules/tools/src/libifm3d_tools/import_app.cpp
@@ -31,7 +31,8 @@
 
 namespace po = boost::program_options;
 
-ifm3d::ImportApp::ImportApp(int argc, const char **argv,
+ifm3d::ImportApp::ImportApp(int argc,
+                            const char** argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
@@ -46,13 +47,16 @@ ifm3d::ImportApp::ImportApp(int argc, const char **argv,
     ("app,a", "If `-c', import the application configuration");
   // clang-format on
 
-
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 
-int ifm3d::ImportApp::Run()
+int
+ifm3d::ImportApp::Run()
 {
   if (this->vm_.count("help"))
     {
@@ -66,7 +70,7 @@ int ifm3d::ImportApp::Run()
   std::string infile = this->vm_["file"].as<std::string>();
   if (infile == "-")
     {
-      ifs.reset(&std::cin, [](...){});
+      ifs.reset(&std::cin, [](...) {});
 
       char b;
       while (ifs->get(b))
@@ -76,8 +80,8 @@ int ifm3d::ImportApp::Run()
     }
   else
     {
-      ifs.reset(new std::ifstream(infile, std::ios::in|std::ios::binary));
-      if (! *ifs)
+      ifs.reset(new std::ifstream(infile, std::ios::in | std::ios::binary));
+      if (!*ifs)
         {
           std::cerr << "Could not open file: " << infile << std::endl;
           throw ifm3d::error_t(IFM3D_IO_ERROR);
@@ -96,7 +100,7 @@ int ifm3d::ImportApp::Run()
     }
 
   std::uint16_t mask = 0x0;
-  if(! this->vm_.count("config"))
+  if (!this->vm_.count("config"))
     {
       this->cam_->ImportIFMApp(bytes);
     }
@@ -115,7 +119,8 @@ int ifm3d::ImportApp::Run()
 
       if (this->vm_.count("app"))
         {
-          mask |= static_cast<std::uint16_t>(ifm3d::Camera::import_flags::APPS);
+          mask |=
+            static_cast<std::uint16_t>(ifm3d::Camera::import_flags::APPS);
         }
 
       this->cam_->ImportIFMConfig(bytes, mask);

--- a/modules/tools/src/libifm3d_tools/import_app.cpp
+++ b/modules/tools/src/libifm3d_tools/import_app.cpp
@@ -35,6 +35,7 @@ ifm3d::ImportApp::ImportApp(int argc, const char **argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
   this->local_opts_.add_options()
     ("file", po::value<std::string>()->default_value("-"),
      "Input file, defaults to `stdin' (good for reading off a pipeline)")
@@ -43,6 +44,7 @@ ifm3d::ImportApp::ImportApp(int argc, const char **argv,
     ("global,g", "If `-c', import the global configuration")
     ("net,n", "If `-c', import the network configuration")
     ("app,a", "If `-c', import the application configuration");
+  // clang-format on
 
 
   po::store(po::command_line_parser(argc, argv).

--- a/modules/tools/src/libifm3d_tools/ls_app.cpp
+++ b/modules/tools/src/libifm3d_tools/ls_app.cpp
@@ -19,12 +19,12 @@
 #include <ifm3d/tools/cmdline_app.h>
 #include <ifm3d/camera/camera.h>
 
-ifm3d::LsApp::LsApp(int argc, const char **argv,
-                    const std::string& name)
+ifm3d::LsApp::LsApp(int argc, const char** argv, const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 { }
 
-int ifm3d::LsApp::Run()
+int
+ifm3d::LsApp::Run()
 {
   if (this->vm_.count("help"))
     {

--- a/modules/tools/src/libifm3d_tools/make_app.cpp
+++ b/modules/tools/src/libifm3d_tools/make_app.cpp
@@ -138,9 +138,11 @@ ifm3d::CmdLineApp::Ptr
 ifm3d::make_app(int argc, const char **argv)
 {
   po::options_description desc;
+  // clang-format off
   desc.add_options()
     ("command", po::value<std::string>()->default_value("version"),
      "ifm3d Sub-command to execute");
+  // clang-format on
 
   po::positional_options_description p;
   p.add("command", 1);

--- a/modules/tools/src/libifm3d_tools/make_app.cpp
+++ b/modules/tools/src/libifm3d_tools/make_app.cpp
@@ -29,113 +29,130 @@
 
 namespace po = boost::program_options;
 
-std::unordered_map<std::string,
-                   std::function<ifm3d::CmdLineApp::Ptr(int, const char**,
-                                                        const std::string&)> >
-app_factory =
-  {
+std::unordered_map<
+  std::string,
+  std::function<ifm3d::CmdLineApp::Ptr(int, const char**, const std::string&)>>
+  app_factory = {
     {"app-types",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::AppTypesApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::AppTypesApp>(argc, argv, cmd);
+     }},
 
     {"config",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::ConfigApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::ConfigApp>(argc, argv, cmd);
+     }},
 
     {"cp",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::CpApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::CpApp>(argc, argv, cmd);
+     }},
 
     {"dump",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::DumpApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::DumpApp>(argc, argv, cmd);
+     }},
 
     {"export",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::ExportApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::ExportApp>(argc, argv, cmd);
+     }},
 
     {"imager-types",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::ImagerTypesApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::ImagerTypesApp>(argc, argv, cmd);
+     }},
 
     {"import",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::ImportApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::ImportApp>(argc, argv, cmd);
+     }},
 
     {"ls",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::LsApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::LsApp>(argc, argv, cmd);
+     }},
 
     {"passwd",
-	 [](int argc, const char** argv, const std::string& cmd)
-	 ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::PasswdApp>(argc, argv, cmd); }},
+     [](int argc, const char** argv, const std::string& cmd)
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::PasswdApp>(argc, argv, cmd);
+     }},
 
     {"reboot",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::RebootApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::RebootApp>(argc, argv, cmd);
+     }},
 
     {"reset",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::ResetApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::ResetApp>(argc, argv, cmd);
+     }},
 
     {"rm",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::RmApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::RmApp>(argc, argv, cmd);
+     }},
 
     {"time",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::TimeApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::TimeApp>(argc, argv, cmd);
+     }},
 
     {"trace",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::TraceApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::TraceApp>(argc, argv, cmd);
+     }},
 
 #if defined(BUILD_MODULE_FRAMEGRABBER)
     {"schema",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::SchemaApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::SchemaApp>(argc, argv, cmd);
+     }},
 
     {"hz",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::HzApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::HzApp>(argc, argv, cmd);
+     }},
 
     {"jitter",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::JitterApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::JitterApp>(argc, argv, cmd);
+     }},
 #endif
 
 #if defined(BUILD_MODULE_SWUPDATER)
     {"swupdate",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::SWUpdateApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::SWUpdateApp>(argc, argv, cmd);
+     }},
 #endif
 
     {"version",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::CmdLineApp>(argc, argv, cmd); }}
-  };
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::CmdLineApp>(argc, argv, cmd);
+     }}};
 
 ifm3d::CmdLineApp::Ptr
-ifm3d::make_app(int argc, const char **argv)
+ifm3d::make_app(int argc, const char** argv)
 {
   po::options_description desc;
   // clang-format off
@@ -148,8 +165,12 @@ ifm3d::make_app(int argc, const char **argv)
   p.add("command", 1);
 
   po::variables_map vm;
-  po::store(po::command_line_parser(argc, argv).
-            options(desc).positional(p).allow_unregistered().run(), vm);
+  po::store(po::command_line_parser(argc, argv)
+              .options(desc)
+              .positional(p)
+              .allow_unregistered()
+              .run(),
+            vm);
   po::notify(vm);
 
   std::string cmd = vm["command"].as<std::string>();

--- a/modules/tools/src/libifm3d_tools/passwd_app.cpp
+++ b/modules/tools/src/libifm3d_tools/passwd_app.cpp
@@ -23,7 +23,8 @@
 
 namespace po = boost::program_options;
 
-ifm3d::PasswdApp::PasswdApp(int argc, const char **argv,
+ifm3d::PasswdApp::PasswdApp(int argc,
+                            const char** argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
@@ -35,8 +36,11 @@ ifm3d::PasswdApp::PasswdApp(int argc, const char **argv,
 	  "disable password on sensor");
   // clang-format on
 
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 
@@ -50,22 +54,23 @@ ifm3d::PasswdApp::Run()
     }
 
   auto const new_password = vm_.count("new") ? true : false;
-  auto const disable = vm_.count("disable") ? vm_["disable"].as<bool>() : false;
+  auto const disable =
+    vm_.count("disable") ? vm_["disable"].as<bool>() : false;
   std::string password = "";
 
   if (new_password && disable)
-  {
-    std::cerr << "invalid option combination" << std::endl;
-	throw po::validation_error(po::validation_error::invalid_option);
-  }
+    {
+      std::cerr << "invalid option combination" << std::endl;
+      throw po::validation_error(po::validation_error::invalid_option);
+    }
   else if (new_password)
-  {
-    password = this->vm_["new"].as<std::string>();
-	this->cam_->SetPassword(password);
-  }
-  else if(disable)
-  {
-    this->cam_->SetPassword(password);
-  }
+    {
+      password = this->vm_["new"].as<std::string>();
+      this->cam_->SetPassword(password);
+    }
+  else if (disable)
+    {
+      this->cam_->SetPassword(password);
+    }
   return 0;
 }

--- a/modules/tools/src/libifm3d_tools/passwd_app.cpp
+++ b/modules/tools/src/libifm3d_tools/passwd_app.cpp
@@ -27,11 +27,13 @@ ifm3d::PasswdApp::PasswdApp(int argc, const char **argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
 	this->local_opts_.add_options()
 	 ("new",po::value<std::string>(),
 	  "password to be set on sensor")
 	 ("disable",po::bool_switch()->default_value(false),
 	  "disable password on sensor");
+  // clang-format on
 
   po::store(po::command_line_parser(argc, argv).
             options(this->local_opts_).allow_unregistered().run(), this->vm_);

--- a/modules/tools/src/libifm3d_tools/reboot_app.cpp
+++ b/modules/tools/src/libifm3d_tools/reboot_app.cpp
@@ -23,7 +23,8 @@
 
 namespace po = boost::program_options;
 
-ifm3d::RebootApp::RebootApp(int argc, const char **argv,
+ifm3d::RebootApp::RebootApp(int argc,
+                            const char** argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
@@ -32,8 +33,11 @@ ifm3d::RebootApp::RebootApp(int argc, const char **argv,
     ("recovery,r", "Reboot into recovery mode");
   // clang-format on
 
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 
@@ -46,10 +50,9 @@ ifm3d::RebootApp::Run()
       return 0;
     }
 
-  ifm3d::Camera::boot_mode mode =
-    this->vm_.count("recovery") ?
-    ifm3d::Camera::boot_mode::RECOVERY :
-    ifm3d::Camera::boot_mode::PRODUCTIVE;
+  ifm3d::Camera::boot_mode mode = this->vm_.count("recovery") ?
+                                    ifm3d::Camera::boot_mode::RECOVERY :
+                                    ifm3d::Camera::boot_mode::PRODUCTIVE;
 
   this->cam_->Reboot(mode);
 

--- a/modules/tools/src/libifm3d_tools/reboot_app.cpp
+++ b/modules/tools/src/libifm3d_tools/reboot_app.cpp
@@ -27,8 +27,10 @@ ifm3d::RebootApp::RebootApp(int argc, const char **argv,
                             const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
   this->local_opts_.add_options()
     ("recovery,r", "Reboot into recovery mode");
+  // clang-format on
 
   po::store(po::command_line_parser(argc, argv).
             options(this->local_opts_).allow_unregistered().run(), this->vm_);

--- a/modules/tools/src/libifm3d_tools/reset_app.cpp
+++ b/modules/tools/src/libifm3d_tools/reset_app.cpp
@@ -24,8 +24,7 @@
 
 namespace po = boost::program_options;
 
-ifm3d::ResetApp::ResetApp(int argc, const char **argv,
-                          const std::string& name)
+ifm3d::ResetApp::ResetApp(int argc, const char** argv, const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
   // clang-format off
@@ -33,8 +32,11 @@ ifm3d::ResetApp::ResetApp(int argc, const char **argv,
     ("reboot,r", "Reboot the sensor after reset");
   // clang-format on
 
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 

--- a/modules/tools/src/libifm3d_tools/reset_app.cpp
+++ b/modules/tools/src/libifm3d_tools/reset_app.cpp
@@ -28,8 +28,10 @@ ifm3d::ResetApp::ResetApp(int argc, const char **argv,
                           const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
   this->local_opts_.add_options()
     ("reboot,r", "Reboot the sensor after reset");
+  // clang-format on
 
   po::store(po::command_line_parser(argc, argv).
             options(this->local_opts_).allow_unregistered().run(), this->vm_);

--- a/modules/tools/src/libifm3d_tools/rm_app.cpp
+++ b/modules/tools/src/libifm3d_tools/rm_app.cpp
@@ -23,8 +23,7 @@
 
 namespace po = boost::program_options;
 
-ifm3d::RmApp::RmApp(int argc, const char **argv,
-                    const std::string& name)
+ifm3d::RmApp::RmApp(int argc, const char** argv, const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
   // clang-format off
@@ -34,12 +33,16 @@ ifm3d::RmApp::RmApp(int argc, const char **argv,
      "Index of application to remove");
   // clang-format on
 
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 
-int ifm3d::RmApp::Run()
+int
+ifm3d::RmApp::Run()
 {
   if (this->vm_.count("help"))
     {

--- a/modules/tools/src/libifm3d_tools/rm_app.cpp
+++ b/modules/tools/src/libifm3d_tools/rm_app.cpp
@@ -27,10 +27,12 @@ ifm3d::RmApp::RmApp(int argc, const char **argv,
                     const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
   this->local_opts_.add_options()
     ("index",
      po::value<int>()->default_value(-1),
      "Index of application to remove");
+  // clang-format on
 
   po::store(po::command_line_parser(argc, argv).
             options(this->local_opts_).allow_unregistered().run(), this->vm_);

--- a/modules/tools/src/libifm3d_tools/swupdater/swupdate_app.cpp
+++ b/modules/tools/src/libifm3d_tools/swupdater/swupdate_app.cpp
@@ -36,6 +36,7 @@ ifm3d::SWUpdateApp::SWUpdateApp(int argc, const char **argv,
                                 const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
   this->local_opts_.add_options()
     ("file", po::value<std::string>()->default_value("-"),
      "Input file, defaults to `stdin' (good for reading off a pipeline)")
@@ -45,6 +46,7 @@ ifm3d::SWUpdateApp::SWUpdateApp(int argc, const char **argv,
      "Reboot from recovery mode to productive mode")
     ("quiet,q", po::bool_switch()->default_value(false),
      "Disable status output");
+  // clang-format on
 
   po::store(po::command_line_parser(argc, argv).
             options(this->local_opts_).allow_unregistered().run(), this->vm_);

--- a/modules/tools/src/libifm3d_tools/swupdater/swupdate_app.cpp
+++ b/modules/tools/src/libifm3d_tools/swupdater/swupdate_app.cpp
@@ -28,11 +28,12 @@
 #include <ifm3d/swupdater.h>
 
 #ifdef _WIN32
-#include <io.h>
-#include <fcntl.h>
+#  include <io.h>
+#  include <fcntl.h>
 #endif
 
-ifm3d::SWUpdateApp::SWUpdateApp(int argc, const char **argv,
+ifm3d::SWUpdateApp::SWUpdateApp(int argc,
+                                const char** argv,
                                 const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
@@ -48,12 +49,16 @@ ifm3d::SWUpdateApp::SWUpdateApp(int argc, const char **argv,
      "Disable status output");
   // clang-format on
 
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 
-int ifm3d::SWUpdateApp::Run()
+int
+ifm3d::SWUpdateApp::Run()
 {
   if (this->vm_.count("help"))
     {
@@ -63,8 +68,8 @@ int ifm3d::SWUpdateApp::Run()
 
   auto const file = vm_.count("file") ? true : false;
   auto const check = vm_.count("check") ? vm_["check"].as<bool>() : false;
-  auto const recovery_reboot = vm_.count("reboot") ?
-    vm_["reboot"].as<bool>() : false;
+  auto const recovery_reboot =
+    vm_.count("reboot") ? vm_["reboot"].as<bool>() : false;
   auto const quiet = vm_.count("quiet") ? vm_["quiet"].as<bool>() : false;
 
   ifm3d::SWUpdater::Ptr swupdater;
@@ -75,42 +80,39 @@ int ifm3d::SWUpdateApp::Run()
   else
     {
       swupdater = std::make_shared<ifm3d::SWUpdater>(
-          this->cam_,
-          [](float p, const std::string& msg)
-          {
-            if (p < 1.0f)
-              {
-                int width = 50;
-                std::cout << "Uploading Firmware: [";
-                int pos = int(width * p);
-                for (int i = 0; i < width; ++i)
-                  {
-                    if (i < pos)
-                      {
-                        std::cout << "=";
-                      }
-                    else if (i==pos)
-                      {
-                        std::cout << ">";
-                      }
-                    else
-                      {
-                        std::cout << " ";
-                      }
-                  }
-                  std::cout << "] " << int(p * 100) << "%\r";
-                  std::cout.flush();
-              }
-            else
-              {
-                std::cout << msg << std::endl;
-              }
-          });
-
+        this->cam_,
+        [](float p, const std::string& msg) {
+          if (p < 1.0f)
+            {
+              int width = 50;
+              std::cout << "Uploading Firmware: [";
+              int pos = int(width * p);
+              for (int i = 0; i < width; ++i)
+                {
+                  if (i < pos)
+                    {
+                      std::cout << "=";
+                    }
+                  else if (i == pos)
+                    {
+                      std::cout << ">";
+                    }
+                  else
+                    {
+                      std::cout << " ";
+                    }
+                }
+              std::cout << "] " << int(p * 100) << "%\r";
+              std::cout.flush();
+            }
+          else
+            {
+              std::cout << msg << std::endl;
+            }
+        });
     }
 
-
-  if(check)
+  if (check)
     {
       if (swupdater->WaitForRecovery(-1))
         {
@@ -135,7 +137,7 @@ int ifm3d::SWUpdateApp::Run()
         }
       return 0;
     }
-  else if(recovery_reboot)
+  else if (recovery_reboot)
     {
       if (!quiet)
         {
@@ -146,21 +148,21 @@ int ifm3d::SWUpdateApp::Run()
         {
           if (!quiet)
             {
-              std::cout << "Timed out waiting for producitve mode" << std::endl;
+              std::cout << "Timed out waiting for producitve mode"
+                        << std::endl;
             }
           return -1;
         }
       return 0;
     }
-  else if(file)
+  else if (file)
     {
       // Reboot to recovery if not already in recovery
       if (!swupdater->WaitForRecovery(-1))
         {
           if (!quiet)
             {
-              std::cout << "Rebooting device to recovery mode..."
-                        << std::endl;
+              std::cout << "Rebooting device to recovery mode..." << std::endl;
             }
           swupdater->RebootToRecovery();
           if (!swupdater->WaitForRecovery(60000))
@@ -186,7 +188,7 @@ int ifm3d::SWUpdateApp::Run()
           _setmode(_fileno(stdin), O_BINARY);
 #endif
 
-          ifs.reset(&std::cin, [](...){});
+          ifs.reset(&std::cin, [](...) {});
 
           char b;
           while (ifs->get(b))
@@ -196,8 +198,9 @@ int ifm3d::SWUpdateApp::Run()
         }
       else
         {
-          ifs.reset(new std::ifstream(infile, std::ios::in|std::ios::binary));
-          if (! *ifs)
+          ifs.reset(
+            new std::ifstream(infile, std::ios::in | std::ios::binary));
+          if (!*ifs)
             {
               std::cerr << "Could not open file: " << infile << std::endl;
               throw ifm3d::error_t(IFM3D_IO_ERROR);
@@ -216,14 +219,14 @@ int ifm3d::SWUpdateApp::Run()
         }
 
       if (!swupdater->FlashFirmware(bytes, 300000))
-      {
-        if (!quiet)
-          {
-            std::cout << "Timed out waiting for flashing to complete"
-                      << std::endl;
-          }
-        return -1;
-      }
+        {
+          if (!quiet)
+            {
+              std::cout << "Timed out waiting for flashing to complete"
+                        << std::endl;
+            }
+          return -1;
+        }
 
       swupdater->RebootToProductive();
       if (!quiet)
@@ -233,7 +236,7 @@ int ifm3d::SWUpdateApp::Run()
         }
       if (!swupdater->WaitForProductive(60000))
         {
-          if(!quiet)
+          if (!quiet)
             {
               std::cout << "Timed out waiting for productive mode"
                         << std::endl;

--- a/modules/tools/src/libifm3d_tools/time_app.cpp
+++ b/modules/tools/src/libifm3d_tools/time_app.cpp
@@ -30,9 +30,11 @@ ifm3d::TimeApp::TimeApp(int argc, const char **argv,
                         const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
   this->local_opts_.add_options()
     ("epoch", po::value<int>(),
      "Secs since Unix epoch encoding time to be set on camera (-1 == now)");
+  // clang-format on
 
   po::store(po::command_line_parser(argc, argv).
             options(this->local_opts_).allow_unregistered().run(), this->vm_);

--- a/modules/tools/src/libifm3d_tools/time_app.cpp
+++ b/modules/tools/src/libifm3d_tools/time_app.cpp
@@ -26,8 +26,7 @@
 
 namespace po = boost::program_options;
 
-ifm3d::TimeApp::TimeApp(int argc, const char **argv,
-                        const std::string& name)
+ifm3d::TimeApp::TimeApp(int argc, const char** argv, const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
   // clang-format off
@@ -36,12 +35,16 @@ ifm3d::TimeApp::TimeApp(int argc, const char **argv,
      "Secs since Unix epoch encoding time to be set on camera (-1 == now)");
   // clang-format on
 
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 
-int ifm3d::TimeApp::Run()
+int
+ifm3d::TimeApp::Run()
 {
   if (this->vm_.count("help"))
     {
@@ -56,8 +59,7 @@ int ifm3d::TimeApp::Run()
                 << "an O3D3XX with firmware >= "
                 << ifm3d::O3D_TIME_SUPPORT_MAJOR << "."
                 << ifm3d::O3D_TIME_SUPPORT_MINOR << "."
-                << ifm3d::O3D_TIME_SUPPORT_PATCH
-                << std::endl;
+                << ifm3d::O3D_TIME_SUPPORT_PATCH << std::endl;
       return 0;
     }
 
@@ -71,8 +73,7 @@ int ifm3d::TimeApp::Run()
     std::stoi(dump["ifm3d"]["Time"]["CurrentTime"].get<std::string>());
   std::time_t curr_time_t = curr_time;
   std::cout << "Local time on camera is: "
-            << std::asctime(std::localtime(&curr_time_t))
-            << std::endl;
+            << std::asctime(std::localtime(&curr_time_t)) << std::endl;
 
   return 0;
 }

--- a/modules/tools/src/libifm3d_tools/trace_app.cpp
+++ b/modules/tools/src/libifm3d_tools/trace_app.cpp
@@ -19,8 +19,7 @@
 #include <ifm3d/tools/cmdline_app.h>
 #include <ifm3d/camera/camera.h>
 
-ifm3d::TraceApp::TraceApp(int argc, const char **argv,
-                    const std::string& name)
+ifm3d::TraceApp::TraceApp(int argc, const char** argv, const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
   // clang-format off
@@ -29,12 +28,16 @@ ifm3d::TraceApp::TraceApp(int argc, const char **argv,
      "Limit the amount of trace log messages printed. (default: all)");
   // clang-format on
 
-  po::store(po::command_line_parser(argc, argv).
-            options(this->local_opts_).allow_unregistered().run(), this->vm_);
+  po::store(po::command_line_parser(argc, argv)
+              .options(this->local_opts_)
+              .allow_unregistered()
+              .run(),
+            this->vm_);
   po::notify(this->vm_);
 }
 
-int ifm3d::TraceApp::Run()
+int
+ifm3d::TraceApp::Run()
 {
   if (this->vm_.count("help"))
     {
@@ -45,16 +48,14 @@ int ifm3d::TraceApp::Run()
   auto limit = 0;
   if (this->vm_.count("limit"))
     {
-      limit = std::max(1,this->vm_["limit"].as<int>());
+      limit = std::max(1, this->vm_["limit"].as<int>());
     }
 
   std::vector<std::string> logs = this->cam_->TraceLogs(limit);
 
-  for (auto& log : logs )
+  for (auto& log : logs)
     {
-      std::cout << log
-                << std::endl
-                << std::flush;
+      std::cout << log << std::endl << std::flush;
     }
 
   return 0;

--- a/modules/tools/src/libifm3d_tools/trace_app.cpp
+++ b/modules/tools/src/libifm3d_tools/trace_app.cpp
@@ -23,9 +23,11 @@ ifm3d::TraceApp::TraceApp(int argc, const char **argv,
                     const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
 {
+  // clang-format off
   this->local_opts_.add_options()
     ("limit,l", po::value<int>(),
      "Limit the amount of trace log messages printed. (default: all)");
+  // clang-format on
 
   po::store(po::command_line_parser(argc, argv).
             options(this->local_opts_).allow_unregistered().run(), this->vm_);


### PR DESCRIPTION
Introducing a .clang_format which best approximates the existing code style of the `ifm3d` codebase.

Changes to code formatting is always a controversial topic, so some words about this change:

**Motivation**: Increase efficiency of distributed team and more readily accept community contributions without spending significant energy on formatting-specific feedback

**Considerations**:
- Existing style should be preserved wherever possible to preserve the history of the codebase (both historical as well as diff tools like `git blame`)
- Any decisions should be based on concrete reasoning rather than personal preferences

The .clang-format file in this diff is a best-effort approximation of the existing `ifm3d` codebase. In case of discrepancies or inconsistencies in the code, the more common option was selected. If no common option was clear, the fallback was to follow the styling found in the [C++ Core Guidlines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines) code examples.

Specific departures from existing style are enumerated below:
- Code is inconsistent regarding space after logical not. Chose no space per C++ Core Guidelines.
- Code is inconsistent about breaking after function return type. Most common pattern is to put the return type on a newline for function definitions but not declarations, so this option was chosen
- Code is inconsistent about space after control statements. Most common choice is to insert the space (`if ()`) which also follows the styling in C++ Core Guidelines
- Code justifies pointers right but references left (`int *c` vs `int& c`) but clang-format treats them the same. Chose left justification to favor type-descriptions per patterns in C++ Core Guidelines.

Finally the following departures from existing style are due to limitations of clang-format:
- clang-format does not allow single-line enum class definitions
- clang-format cannot do allman style bracing for lambdas so K&R braces are used.
  - NOTE: clang 11 has support for allman style bracing in lambdas; can revisit once clang-format 11 is more readily available
- clang format removes extra space on closing nested templates (`<<int> >`) and is not tunable
- clang format adds spaces around mathematical operations as well as the arrow keyword for trailing return types and is not tunable