### PR TITLE
Add GitHub Action for linting with clang-format on push/PR

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,20 @@
+name: clang-format-lint
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  check-formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.8
+      with:
+        source: '.'
+        extensions: 'h,hpp,cpp'
+        exclude: './third-party ./cmake ./docker ./snap ./modules/tools/contrib ./modules/camera/include/ifm3d/contrib'
+        clangFormatVersion: 10
+

--- a/modules/framegrabber/src/libifm3d_framegrabber/frame_grabber_impl.hpp
+++ b/modules/framegrabber/src/libifm3d_framegrabber/frame_grabber_impl.hpp
@@ -490,25 +490,25 @@ ifm3d::FrameGrabber::Impl::Run()
 
   // For non-O3X devices setting the schema via PCIC, we get acknowledgement of
   // our schema, then start processing the stream of pixel bytes
-  auto result_schema_write_handler =
-    [this](const asio::error_code& ec, std::size_t bytes_xferd) {
-      if (ec)
-        {
-          throw ifm3d::error_t(ec.value());
-        }
-      this->ticket_buffer_.clear();
-      this->ticket_buffer_.resize(ifm3d::TICKET_ID_SZ);
+  auto result_schema_write_handler = [this](const asio::error_code& ec,
+                                            std::size_t bytes_xferd) {
+    if (ec)
+      {
+        throw ifm3d::error_t(ec.value());
+      }
+    this->ticket_buffer_.clear();
+    this->ticket_buffer_.resize(ifm3d::TICKET_ID_SZ);
 
-      this->sock_.async_read_some(
-        asio::buffer(this->ticket_buffer_.data(), ifm3d::TICKET_ID_SZ),
-        std::bind(&ifm3d::FrameGrabber::Impl::TicketHandler,
-                  this,
-                  std::placeholders::_1,
-                  std::placeholders::_2,
-                  0));
+    this->sock_.async_read_some(
+      asio::buffer(this->ticket_buffer_.data(), ifm3d::TICKET_ID_SZ),
+      std::bind(&ifm3d::FrameGrabber::Impl::TicketHandler,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2,
+                0));
 
-      this->pcic_ready_.store(true);
-    };
+    this->pcic_ready_.store(true);
+  };
 
   try
     {


### PR DESCRIPTION
Set up a clang-format based linting workflow for GitHub Actions.

Also discovered that frame_grabber_impl.hpp is not formatted properly for whatever reason; applied clang-format to that file to make sure the new action passes cleanly.