### PR TITLE
Fix for github Action CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,23 +17,22 @@ jobs:
       shell: cmd
       run: |
         mkdir c:\deps\install
-        mkdir c:\deps\install\Boost
+        mkdir c:\deps\Boost #boost will not be cache for size issue 
 
     - name: Check cache for prebuilt dependencies
       id: get-dep-cache
       uses: actions/cache@v1.0.3
       with:
         path: c:\deps\install
-        key: ifm3d-deps-6 # Increment to force-clear cache
+        key: ifm3d-deps-7 # Increment to force-clear cache
 
     - name: Install boost
       id: install-boost
-      if: steps.get-dep-cache.outputs.cache-hit != 'true'
       run : |
        $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.1-64.exe"
        (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
-       Start-Process -Wait -FilePath "$env:TEMP\boost.exe" -ArgumentList "/silent /sp- /suppressmsgboxes /dir=c:\deps\install\Boost"
-       echo '::set-output name=BOOST_ROOT::c:\deps\install\Boost'
+       Start-Process -Wait -FilePath "$env:TEMP\boost.exe" -ArgumentList "/silent /sp- /suppressmsgboxes /dir=c:\deps\Boost"
+       echo '::set-output name=BOOST_ROOT::c:\deps\Boost'
        
     - name: Build dependency - curl
       if: steps.get-dep-cache.outputs.cache-hit != 'true'
@@ -123,11 +122,13 @@ jobs:
 
     - name: Build ifm3d
       shell: cmd
+      env:
+        BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
       run: |
         mkdir \ifm3d\install
         mkdir build
         cd build
-        cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SDK_PKG=ON -DGTEST_CMAKE_DIR=c:\deps\install\googletest\googletest -Dgtest_force_shared_crt=TRUE -DCMAKE_PREFIX_PATH=c:\deps\install -DBOOST_ROOT=c:\deps\install\Boost -DBoost_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\ifm3d\install -DBUILD_MODULE_OPENCV=ON -DBUILD_MODULE_PCICCLIENT=ON ..
+        cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SDK_PKG=ON -DGTEST_CMAKE_DIR=c:\deps\install\googletest\googletest -Dgtest_force_shared_crt=TRUE -DCMAKE_PREFIX_PATH=c:\deps\install -DBOOST_ROOT=%BOOST_ROOT% -DBoost_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\ifm3d\install -DBUILD_MODULE_OPENCV=ON -DBUILD_MODULE_PCICCLIENT=ON ..
         cmake --build . --clean-first --config Release --target INSTALL
 
     - name: Copy third party dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,32 +12,29 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v2
+      
+    - name: Create output directory
+      shell: cmd
+      run: |
+        mkdir c:\deps\install
+        mkdir c:\deps\install\Boost
 
     - name: Check cache for prebuilt dependencies
       id: get-dep-cache
       uses: actions/cache@v1.0.3
       with:
         path: c:\deps\install
-        key: ifm3d-deps-2 # Increment to force-clear cache
-
-    - name: Create output directory
-      if: steps.get-dep-cache.outputs.cache-hit != 'true'
-      shell: cmd
-      run: mkdir c:\deps\install
+        key: ifm3d-deps-3 # Increment to force-clear cache
 
     - name: Install boost
-      uses: MarkusJx/install-boost@v1.0.1
       id: install-boost
-      with:
-       # REQUIRED: Specify the required boost version
-       # A list of supported versions can be found here:
-       # https://github.com/actions/boost-versions/blob/main/versions-manifest.json
-       boost_version: 1.73.0
-       # OPTIONAL: Specify a toolset on windows
-       toolset: msvc14.1
-       # OPTIONAL: Specify a custon install location
-       boost_install_dir: c:\deps
-
+      if: steps.get-dep-cache.outputs.cache-hit != 'true'
+      run : |
+       $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.1-64.exe"
+       (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
+       Start-Process -Wait -FilePath "$env:TEMP\boost.exe" -ArgumentList "/silent /sp- /suppressmsgboxes /dir=c:\deps\install\Boost"
+       echo '::set-output name=BOOST_ROOT::c:\deps\install\Boost'
+       
     - name: Build dependency - curl
       if: steps.get-dep-cache.outputs.cache-hit != 'true'
       shell: cmd
@@ -130,7 +127,7 @@ jobs:
         mkdir \ifm3d\install
         mkdir build
         cd build
-        cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SDK_PKG=ON -DGTEST_CMAKE_DIR=c:\deps\install\googletest\googletest -Dgtest_force_shared_crt=TRUE -DCMAKE_PREFIX_PATH=c:\deps\install -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\ifm3d\install -DBUILD_MODULE_OPENCV=ON -DBUILD_MODULE_PCICCLIENT=ON ..
+        cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SDK_PKG=ON -DGTEST_CMAKE_DIR=c:\deps\install\googletest\googletest -Dgtest_force_shared_crt=TRUE -DCMAKE_PREFIX_PATH=c:\deps\install -DBOOST_ROOT=c:\deps\install\Boost -DBoost_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\ifm3d\install -DBUILD_MODULE_OPENCV=ON -DBUILD_MODULE_PCICCLIENT=ON ..
         cmake --build . --clean-first --config Release --target INSTALL
 
     - name: Copy third party dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/cache@v1.0.3
       with:
         path: c:\deps\install
-        key: ifm3d-deps-3 # Increment to force-clear cache
+        key: ifm3d-deps-6 # Increment to force-clear cache
 
     - name: Install boost
       id: install-boost

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,19 @@ jobs:
       shell: cmd
       run: mkdir c:\deps\install
 
+    - name: Install boost
+      uses: MarkusJx/install-boost@v1.0.1
+      id: install-boost
+      with:
+       # REQUIRED: Specify the required boost version
+       # A list of supported versions can be found here:
+       # https://github.com/actions/boost-versions/blob/main/versions-manifest.json
+       boost_version: 1.73.0
+       # OPTIONAL: Specify a toolset on windows
+       toolset: msvc14.1
+       # OPTIONAL: Specify a custon install location
+       boost_install_dir: c:\deps
+
     - name: Build dependency - curl
       if: steps.get-dep-cache.outputs.cache-hit != 'true'
       shell: cmd
@@ -83,12 +96,14 @@ jobs:
     - name: Build dependency - PCL
       if: steps.get-dep-cache.outputs.cache-hit != 'true'
       shell: cmd
+      env:
+        BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
       run: |
         cd /d c:\deps
         git clone --branch pcl-1.10.1 https://github.com/PointCloudLibrary/pcl.git
         mkdir pcl\build
         cd pcl\build
-        cmake -G "Visual Studio 15 2017 Win64" -DBOOST_ROOT=%BOOST_ROOT_1_72_0% -DPCL_ENABLE_SSE=OFF -DWITH_CUDA=OFF -DWITH_DAVIDSDK=OFF -DWITH_DOCS=OFF -DWITH_DSSDK=OFF -DWITH_ENSENSO=OFF -DWITH_FZAPI=OFF -DWITH_LIBUSB=OFF -DWITH_OPENGL=OFF -DWITH_VTK=OFF -DWITH_OPENNI=OFF -DWITH_OPENNI2=OFF -DWITH_PCAP=OFF -DWITH_PNG=OFF -DWITH_QHULL=OFF -DWITH_QT=OFF -DWITH_RSSDK=OFF  -DBUILD_tools=OFF -DBUILD_visualization=OFF -DBUILD_features=OFF -DBUILD_filters=OFF -DBUILD_global_tests=OFF -DBUILD_io=OFF -DBUILD_kdtree=OFF -DBUILD_keypoints=OFF -DBUILD_octree=OFF -DBUILD_range_image=OFF -DBUILD_registration=OFF -DBUILD_sample_consensus=OFF -DBUILD_segmentation=OFF -DBUILD_surface=OFF -DCMAKE_INSTALL_PREFIX=c:\deps\install ..
+        cmake -G "Visual Studio 15 2017 Win64" -DBOOST_ROOT=%BOOST_ROOT% -DPCL_ENABLE_SSE=OFF -DWITH_CUDA=OFF -DWITH_DAVIDSDK=OFF -DWITH_DOCS=OFF -DWITH_DSSDK=OFF -DWITH_ENSENSO=OFF -DWITH_FZAPI=OFF -DWITH_LIBUSB=OFF -DWITH_OPENGL=OFF -DWITH_VTK=OFF -DWITH_OPENNI=OFF -DWITH_OPENNI2=OFF -DWITH_PCAP=OFF -DWITH_PNG=OFF -DWITH_QHULL=OFF -DWITH_QT=OFF -DWITH_RSSDK=OFF  -DBUILD_tools=OFF -DBUILD_visualization=OFF -DBUILD_features=OFF -DBUILD_filters=OFF -DBUILD_global_tests=OFF -DBUILD_io=OFF -DBUILD_kdtree=OFF -DBUILD_keypoints=OFF -DBUILD_octree=OFF -DBUILD_range_image=OFF -DBUILD_registration=OFF -DBUILD_sample_consensus=OFF -DBUILD_segmentation=OFF -DBUILD_surface=OFF -DCMAKE_INSTALL_PREFIX=c:\deps\install ..
         cmake --build . --clean-first --config Release --target INSTALL
 
     - name: Build dependency - OpenCV
@@ -115,7 +130,7 @@ jobs:
         mkdir \ifm3d\install
         mkdir build
         cd build
-        cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SDK_PKG=ON -DGTEST_CMAKE_DIR=c:\deps\install\googletest\googletest -Dgtest_force_shared_crt=TRUE -DCMAKE_PREFIX_PATH=c:\deps\install -DBOOST_ROOT=%BOOST_ROOT_1_72_0% -DBoost_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\ifm3d\install -DBUILD_MODULE_OPENCV=ON -DBUILD_MODULE_PCICCLIENT=ON ..
+        cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SDK_PKG=ON -DGTEST_CMAKE_DIR=c:\deps\install\googletest\googletest -Dgtest_force_shared_crt=TRUE -DCMAKE_PREFIX_PATH=c:\deps\install -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\ifm3d\install -DBUILD_MODULE_OPENCV=ON -DBUILD_MODULE_PCICCLIENT=ON ..
         cmake --build . --clean-first --config Release --target INSTALL
 
     - name: Copy third party dependencies

--- a/.github/workflows/windows_vs2019.yml
+++ b/.github/workflows/windows_vs2019.yml
@@ -19,7 +19,6 @@ jobs:
         echo "C:/Program Files/Git/usr/bin" >> $GITHUB_PATH
         
     - name: Create output directory
-      if: steps.get-dep-2019-cache.outputs.cache-hit != 'true'
       shell: cmd
       run: |
         mkdir c:\deps2019\install
@@ -31,13 +30,6 @@ jobs:
       with:
         path: c:\deps2019\install
         key: ifm3d-2019-deps-5 # Increment to force-clear cache
-
-    - name: Create output directory
-      if: steps.get-dep-2019-cache.outputs.cache-hit != 'true'
-      shell: cmd
-      run: |
-        mkdir c:\deps2019\install
-        mkdir c:\deps2019\install\Boost
       
     - name: Install boost
       id: install-boost

--- a/.github/workflows/windows_vs2019.yml
+++ b/.github/workflows/windows_vs2019.yml
@@ -22,23 +22,22 @@ jobs:
       shell: cmd
       run: |
         mkdir c:\deps2019\install
-        mkdir c:\deps2019\install\Boost
+        mkdir c:\deps2019\Boost # boost will not be cache due to size limit
 
     - name: Check cache for prebuilt dependencies
       id: get-dep-2019-cache
       uses: actions/cache@v2
       with:
         path: c:\deps2019\install
-        key: ifm3d-2019-deps-5 # Increment to force-clear cache
+        key: ifm3d-2019-deps-9 # Increment to force-clear cache
       
     - name: Install boost
       id: install-boost
-      if: steps.get-dep-2019-cache.outputs.cache-hit != 'true'
       run : |
         $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"
         (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
-        Start-Process -Wait -FilePath "$env:TEMP\boost.exe" -ArgumentList "/silent /sp- /suppressmsgboxes /dir=c:\deps2019\install\Boost"
-        echo '::set-output name=BOOST_ROOT::c:\deps2019\install\Boost'
+        Start-Process -Wait -FilePath "$env:TEMP\boost.exe" -ArgumentList "/silent /sp- /suppressmsgboxes /dir=c:\deps2019\Boost"
+        echo '::set-output name=BOOST_ROOT::c:\deps2019\Boost'
 
     - name: Build dependency - curl
       if: steps.get-dep-2019-cache.outputs.cache-hit != 'true'
@@ -128,11 +127,13 @@ jobs:
 
     - name: Build ifm3d
       shell: cmd
+      env:
+        BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
       run: |
         mkdir \ifm3d\install2019
         mkdir build
         cd build
-        cmake -G "Visual Studio 16 2019" -Ax64 -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SDK_PKG=ON -DGTEST_CMAKE_DIR=c:\deps2019\install\googletest\googletest -Dgtest_force_shared_crt=TRUE -DCMAKE_PREFIX_PATH=c:\deps2019\install -DBOOST_ROOT=c:\deps2019\install\Boost -DBoost_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\ifm3d\install2019 -DBUILD_MODULE_OPENCV=ON -DBUILD_MODULE_PCICCLIENT=ON ..
+        cmake -G "Visual Studio 16 2019" -Ax64 -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SDK_PKG=ON -DGTEST_CMAKE_DIR=c:\deps2019\install\googletest\googletest -Dgtest_force_shared_crt=TRUE -DCMAKE_PREFIX_PATH=c:\deps2019\install -DBOOST_ROOT=%BOOST_ROOT% -DBoost_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\ifm3d\install2019 -DBUILD_MODULE_OPENCV=ON -DBUILD_MODULE_PCICCLIENT=ON ..
         cmake --build . --clean-first --config Release --target INSTALL
 
     - name: Copy third party dependencies

--- a/.github/workflows/windows_vs2019.yml
+++ b/.github/workflows/windows_vs2019.yml
@@ -17,18 +17,36 @@ jobs:
       shell: cmd
       run: |
         echo "C:/Program Files/Git/usr/bin" >> $GITHUB_PATH
+        
+    - name: Create output directory
+      if: steps.get-dep-2019-cache.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        mkdir c:\deps2019\install
+        mkdir c:\deps2019\install\Boost
 
     - name: Check cache for prebuilt dependencies
       id: get-dep-2019-cache
       uses: actions/cache@v2
       with:
         path: c:\deps2019\install
-        key: ifm3d-2019-deps-3 # Increment to force-clear cache
+        key: ifm3d-2019-deps-5 # Increment to force-clear cache
 
     - name: Create output directory
       if: steps.get-dep-2019-cache.outputs.cache-hit != 'true'
       shell: cmd
-      run: mkdir c:\deps2019\install
+      run: |
+        mkdir c:\deps2019\install
+        mkdir c:\deps2019\install\Boost
+      
+    - name: Install boost
+      id: install-boost
+      if: steps.get-dep-2019-cache.outputs.cache-hit != 'true'
+      run : |
+        $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"
+        (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
+        Start-Process -Wait -FilePath "$env:TEMP\boost.exe" -ArgumentList "/silent /sp- /suppressmsgboxes /dir=c:\deps2019\install\Boost"
+        echo '::set-output name=BOOST_ROOT::c:\deps2019\install\Boost'
 
     - name: Build dependency - curl
       if: steps.get-dep-2019-cache.outputs.cache-hit != 'true'
@@ -88,12 +106,14 @@ jobs:
     - name: Build dependency - PCL
       if: steps.get-dep-2019-cache.outputs.cache-hit != 'true'
       shell: cmd
+      env:
+        BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
       run: |
         cd /d c:\deps2019
         git clone --branch pcl-1.10.1 https://github.com/PointCloudLibrary/pcl.git
         mkdir pcl\build
         cd pcl\build
-        cmake -G "Visual Studio 16 2019" -Ax64 -DBOOST_ROOT=%BOOST_ROOT_1_72_0% -DPCL_ENABLE_SSE=OFF -DWITH_CUDA=OFF -DWITH_DAVIDSDK=OFF -DWITH_DOCS=OFF -DWITH_DSSDK=OFF -DWITH_ENSENSO=OFF -DWITH_FZAPI=OFF -DWITH_LIBUSB=OFF -DWITH_OPENGL=OFF -DWITH_VTK=OFF -DWITH_OPENNI=OFF -DWITH_OPENNI2=OFF -DWITH_PCAP=OFF -DWITH_PNG=OFF -DWITH_QHULL=OFF -DWITH_QT=OFF -DWITH_RSSDK=OFF  -DBUILD_tools=OFF -DBUILD_visualization=OFF -DBUILD_features=OFF -DBUILD_filters=OFF -DBUILD_global_tests=OFF -DBUILD_io=OFF -DBUILD_kdtree=OFF -DBUILD_keypoints=OFF -DBUILD_octree=OFF -DBUILD_range_image=OFF -DBUILD_registration=OFF -DBUILD_sample_consensus=OFF -DBUILD_segmentation=OFF -DBUILD_surface=OFF  -DCMAKE_INSTALL_PREFIX=c:\deps2019\install ..
+        cmake -G "Visual Studio 16 2019" -Ax64 -DBOOST_ROOT=%BOOST_ROOT% -DPCL_ENABLE_SSE=OFF -DWITH_CUDA=OFF -DWITH_DAVIDSDK=OFF -DWITH_DOCS=OFF -DWITH_DSSDK=OFF -DWITH_ENSENSO=OFF -DWITH_FZAPI=OFF -DWITH_LIBUSB=OFF -DWITH_OPENGL=OFF -DWITH_VTK=OFF -DWITH_OPENNI=OFF -DWITH_OPENNI2=OFF -DWITH_PCAP=OFF -DWITH_PNG=OFF -DWITH_QHULL=OFF -DWITH_QT=OFF -DWITH_RSSDK=OFF  -DBUILD_tools=OFF -DBUILD_visualization=OFF -DBUILD_features=OFF -DBUILD_filters=OFF -DBUILD_global_tests=OFF -DBUILD_io=OFF -DBUILD_kdtree=OFF -DBUILD_keypoints=OFF -DBUILD_octree=OFF -DBUILD_range_image=OFF -DBUILD_registration=OFF -DBUILD_sample_consensus=OFF -DBUILD_segmentation=OFF -DBUILD_surface=OFF  -DCMAKE_INSTALL_PREFIX=c:\deps2019\install ..
         cmake --build . --clean-first --config Release --target INSTALL
 
     - name: Build dependency - OpenCV
@@ -120,7 +140,7 @@ jobs:
         mkdir \ifm3d\install2019
         mkdir build
         cd build
-        cmake -G "Visual Studio 16 2019" -Ax64 -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SDK_PKG=ON -DGTEST_CMAKE_DIR=c:\deps2019\install\googletest\googletest -Dgtest_force_shared_crt=TRUE -DCMAKE_PREFIX_PATH=c:\deps2019\install -DBOOST_ROOT=%BOOST_ROOT_1_72_0% -DBoost_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\ifm3d\install2019 -DBUILD_MODULE_OPENCV=ON -DBUILD_MODULE_PCICCLIENT=ON ..
+        cmake -G "Visual Studio 16 2019" -Ax64 -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SDK_PKG=ON -DGTEST_CMAKE_DIR=c:\deps2019\install\googletest\googletest -Dgtest_force_shared_crt=TRUE -DCMAKE_PREFIX_PATH=c:\deps2019\install -DBOOST_ROOT=c:\deps2019\install\Boost -DBoost_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\ifm3d\install2019 -DBUILD_MODULE_OPENCV=ON -DBUILD_MODULE_PCICCLIENT=ON ..
         cmake --build . --clean-first --config Release --target INSTALL
 
     - name: Copy third party dependencies


### PR DESCRIPTION
* Github Actions windows  builds were failing as Github action decided to remove pre installed Boost from windows server 
* This PR Install Boost boost binaries from pre built installer provided by Boost.org
* Fixed some cache related issues 
* Boost binaries are not cached due to size limit on cache memory which is 400MB