### PR TITLE
device discovery feature as per #194 and resolving #286

### DIFF
--- a/doc/cmdline.md
+++ b/doc/cmdline.md
@@ -33,6 +33,8 @@ These are common commands used in various situations:
     cp            Create a new application on the sensor,
                   bootstrapped from a copy of an existing one.
 
+    discover      Discover ifm devices on the network.
+
     dump          Serialize the sensor state to JSON.
 
     export        Export an application or whole sensor configuration

--- a/doc/cmdline.md
+++ b/doc/cmdline.md
@@ -33,7 +33,8 @@ These are common commands used in various situations:
     cp            Create a new application on the sensor,
                   bootstrapped from a copy of an existing one.
 
-    discover      Discover ifm devices on the network.
+    discover      Discover ifm devices on the network and can set
+                  temporary ip-address to device.
 
     dump          Serialize the sensor state to JSON.
 
@@ -359,5 +360,49 @@ And, double checking...
 $ ifm3d time
 Local time on camera is: Mon May  7 16:22:09 2018
 ```
+
+Example: Discover ifm3d vision device over network
+--------------------------------------------------
+
+To discover ifm vision devices on network we use the `discover` subcommand.
+This command also provides temporary ip-address change of device,
+which is useful if device was configured with ip-address other than in current
+network subnet. Let's look at its usage
+
+```
+$ ifm3d discover --help
+Usage:
+  ifm3d [<global options>] discover [<discover options>]
+
+ global options:
+  -h, --help  Produce this help message and exit
+
+ discover options:
+      --mac arg     MAC address of the device (default: )
+      --tempip arg  IP address (default: )
+```
+
+To discover ifm vision devices on network we can issue discover subcommand
+
+```
+ifm3d discover
+192.168.0.69 mac = 00:02:4b:e4:e8:33 (unknown)
+192.168.0.65 mac = 00:02:01:40:8e:a3 (O3D)
+192.168.0.67 mac = 00:02:01:40:a2:f0 (O3X)
+192.168.0.73 mac = 00:02:01:22:b4:29 (unknown)
+192.168.0.71 mac = 00:02:01:40:a0:26 (O3D)
+```
+
+discover command shows ip-address, MAC-ID, and type of devices,
+unknow type are devices not supported by ifm3d.
+
+Temporary IP change of the device
+```
+ifm3d discover --mac=00:02:01:50:4f:d3 --tempip=172.xx.xx.xx
+
+```
+This will change the ip address of device with provided mac to 172.xx.xx.xx,
+This ip-address will be reset after the reboot of device. To set the permanent
+ip-address please use ```ifm3d config``` command.
 
 (More examples to follow)

--- a/modules/camera/include/ifm3d/camera/camera.h
+++ b/modules/camera/include/ifm3d/camera/camera.h
@@ -147,10 +147,24 @@ namespace ifm3d
     /**
      * @brief This function Provides a convinent way to find all
      *   ifm devices on the network.
-     * @return : vector of ip-address all the discovered devices
-     *  on network.
+     * @return : vector of IFMNetworkDevice found on the network
      */
     static std::vector<ifm3d::IFMNetworkDevice> DeviceDiscovery();
+
+    /**
+     * @brief This function Provides a convinent way to set the tempIP
+     * Address on the device.
+     * @param [in] dev_mac MAC address of the device which need a temp IP
+     * @param [in] temp_ip Ip address for the device
+     * @return : vector of IFMNetworkDevice if the Setting the IP is successful
+     * @ Note rebooting the device will loose the temp IP to set the permanent
+     * IP on device use FromJSON function. Setting temporary I pis very useful
+     * if device is on another subnet and user wants a connection to device or
+     * in case of changing the local link address to network address.
+     */
+    static std::vector<ifm3d::IFMNetworkDevice> SetTempIpAddress(
+      const std::string& dev_mac,
+      const std::string& temp_ip);
 
     /**
      * Factory function for instantiating the proper subclass based on h/w

--- a/modules/camera/include/ifm3d/camera/camera.h
+++ b/modules/camera/include/ifm3d/camera/camera.h
@@ -16,6 +16,7 @@
 #include <unordered_map>
 #include <ifm3d/contrib/nlohmann/json.hpp>
 #include <ifm3d/camera/camera_export.h>
+#include <ifm3d/camera/ifm_network_device.h>
 
 using json = nlohmann::json;
 
@@ -149,7 +150,7 @@ namespace ifm3d
      * @return : vector of ip-address all the discovered devices
      *  on network.
      */
-    static std::vector<std::string> DeviceDiscovery();
+    static std::vector<ifm3d::IFMNetworkDevice> DeviceDiscovery();
 
     /**
      * Factory function for instantiating the proper subclass based on h/w

--- a/modules/camera/include/ifm3d/camera/camera.h
+++ b/modules/camera/include/ifm3d/camera/camera.h
@@ -144,6 +144,14 @@ namespace ifm3d
     };
 
     /**
+     * @brief This function Provides a convinent way to find all
+     *   ifm devices on the network.
+     * @return : vector of ip-address all the discovered devices
+     *  on network.
+     */
+    static std::vector<std::string> DeviceDiscovery();
+
+    /**
      * Factory function for instantiating the proper subclass based on h/w
      * probing.
      *

--- a/modules/camera/include/ifm3d/camera/ifm_network_device.h
+++ b/modules/camera/include/ifm3d/camera/ifm_network_device.h
@@ -1,0 +1,71 @@
+// -*- c++ -*-
+/*
+ * Copyright 2020-present ifm electronic, gmbh
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __IFM3D_IFM_NETWORK_DEVICE_H__
+#define __IFM3D_IFM_NETWORK_DEVICE_H__
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace ifm3d
+{
+  using Data = std::vector<unsigned char>;
+  class IFMNetworkDevice
+  {
+  public:
+    IFMNetworkDevice(Data& data, const std::string& ip_address_via_interface);
+
+    /** Ip Address of the device */
+    std::string GetIPAddress() const;
+
+    /** Mac Address of the device */
+    std::string GetMACAddress() const;
+
+    /** Netmask of the network of camera */
+    std::string GetNetmask() const;
+
+    /** Gateway of the device*/
+    std::string GetGateway() const;
+
+    /** Port on which device discovery is done*/
+    uint16_t GetPort() const;
+
+    /** Device gives some additional information via those flags */
+    uint16_t GetFlag() const;
+
+    /** Hostname of the device */
+    std::string GetHostName() const;
+
+    /** Device name */
+    std::string GetDeviceName() const;
+
+    /** Vendor ID of the device */
+    uint16_t GetVendorId() const;
+
+    /** Device ID of the device */
+    uint16_t GetDeviceId() const;
+
+    /** Founf via interface */
+    std::string GetFoundVia() const;
+
+  private:
+    std::string ip_address_;
+    std::string mac_;
+    std::string subnet_;
+    std::string gateway_;
+    uint16_t port_;
+    uint16_t flags_;
+    std::string hostname_;
+    std::string device_name_;
+    uint16_t vendor_id_;
+    uint16_t device_id_;
+    std::string found_via_;
+  };
+
+} // end: namespace ifm3d
+
+#endif // __IFM3D_IFM_NETWORK_DEVICE_H__

--- a/modules/camera/include/ifm3d/camera/ifm_network_device.h
+++ b/modules/camera/include/ifm3d/camera/ifm_network_device.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __IFM3D_IFM_NETWORK_DEVICE_H__
-#define __IFM3D_IFM_NETWORK_DEVICE_H__
+#ifndef IFM3D_IFM_NETWORK_DEVICE_H
+#define IFM3D_IFM_NETWORK_DEVICE_H
 
 #include <memory>
 #include <string>
@@ -68,4 +68,4 @@ namespace ifm3d
 
 } // end: namespace ifm3d
 
-#endif // __IFM3D_IFM_NETWORK_DEVICE_H__
+#endif // IFM3D_IFM_NETWORK_DEVICE_H

--- a/modules/camera/src/libifm3d_camera/CMakeLists.txt
+++ b/modules/camera/src/libifm3d_camera/CMakeLists.txt
@@ -48,6 +48,7 @@ target_include_directories(ifm3d_camera
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${IFM3D_CAMERA_BINARY_DIR}/include>
   PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/third-party/asio/asio/include>
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${XMLRPC_INCLUDE_DIRS}
     )
@@ -67,6 +68,7 @@ target_compile_options(ifm3d_camera
 if(WIN32)
   target_compile_definitions(
     ifm3d_camera PRIVATE
+    ASIO_STANDALONE
     IFM3D_CAMERA_DLL_BUILD=1
     )
 endif(WIN32)

--- a/modules/camera/src/libifm3d_camera/CMakeLists.txt
+++ b/modules/camera/src/libifm3d_camera/CMakeLists.txt
@@ -83,7 +83,7 @@ target_link_libraries(
     ${LIB_xmlrpc_client}
     ${LIB_xmlrpcxx}
     ${LIB_xmlrpc}
-    asio
+    $<BUILD_INTERFACE:asio>
   )
 
 set_target_properties(

--- a/modules/camera/src/libifm3d_camera/CMakeLists.txt
+++ b/modules/camera/src/libifm3d_camera/CMakeLists.txt
@@ -48,7 +48,6 @@ target_include_directories(ifm3d_camera
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${IFM3D_CAMERA_BINARY_DIR}/include>
   PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/third-party/asio/asio/include>
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${XMLRPC_INCLUDE_DIRS}
     )
@@ -84,6 +83,7 @@ target_link_libraries(
     ${LIB_xmlrpc_client}
     ${LIB_xmlrpcxx}
     ${LIB_xmlrpc}
+    asio
   )
 
 set_target_properties(

--- a/modules/camera/src/libifm3d_camera/camera.cpp
+++ b/modules/camera/src/libifm3d_camera/camera.cpp
@@ -184,10 +184,18 @@ std::vector<ifm3d::IFMNetworkDevice>
 ifm3d::Camera::DeviceDiscovery()
 {
   ifm3d::IFMDeviceDiscovery ifm_discovery;
-  auto devices = ifm_discovery.NetworkSearch();
+  auto devices = ifm_discovery.SearchDevices();
   return devices;
 }
 
+std::vector<ifm3d::IFMNetworkDevice>
+ifm3d::Camera::SetTempIpAddress(const std::string& dev_mac,
+                                const std::string& temp_ip)
+{
+  ifm3d::IFMDeviceDiscovery ifm_discovery;
+  auto devices = ifm_discovery.SetTempIpaddress(dev_mac, temp_ip);
+  return devices;
+}
 //================================================
 // Factory function for making cameras
 //================================================

--- a/modules/camera/src/libifm3d_camera/camera.cpp
+++ b/modules/camera/src/libifm3d_camera/camera.cpp
@@ -180,17 +180,12 @@ RO_LUT=
 // Function for Searching Devices on Network
 //================================================
 
-std::vector<std::string>
+std::vector<ifm3d::IFMNetworkDevice>
 ifm3d::Camera::DeviceDiscovery()
 {
   ifm3d::IFMDeviceDiscovery ifm_discovery;
   auto devices = ifm_discovery.NetworkSearch();
-  std::vector<std::string> device_list;
-  for (auto & device : devices)
-    {
-      device_list.push_back(device.ip_address);
-    }
-  return device_list;
+  return devices;
 }
 
 //================================================

--- a/modules/camera/src/libifm3d_camera/camera.cpp
+++ b/modules/camera/src/libifm3d_camera/camera.cpp
@@ -20,6 +20,7 @@
 #include <ifm3d/camera/version.h>
 #include <ifm3d/camera/util.h>
 #include <camera_impl.hpp>
+#include <discovery.hpp>
 
 //================================================
 // Public constants
@@ -174,6 +175,23 @@ RO_LUT=
     }
   };
 // clang-format on
+
+//================================================
+// Function for Searching Devices on Network
+//================================================
+
+std::vector<std::string>
+ifm3d::Camera::DeviceDiscovery()
+{
+  ifm3d::IFMDeviceDiscovery ifm_discovery;
+  auto devices = ifm_discovery.NetworkSearch();
+  std::vector<std::string> device_list;
+  for (auto & device : devices)
+  {
+    device_list.push_back(device.ip_address);
+  }
+  return device_list;
+}
 
 //================================================
 // Factory function for making cameras

--- a/modules/camera/src/libifm3d_camera/camera.cpp
+++ b/modules/camera/src/libifm3d_camera/camera.cpp
@@ -187,9 +187,9 @@ ifm3d::Camera::DeviceDiscovery()
   auto devices = ifm_discovery.NetworkSearch();
   std::vector<std::string> device_list;
   for (auto & device : devices)
-  {
-    device_list.push_back(device.ip_address);
-  }
+    {
+      device_list.push_back(device.ip_address);
+    }
   return device_list;
 }
 

--- a/modules/camera/src/libifm3d_camera/discovery.hpp
+++ b/modules/camera/src/libifm3d_camera/discovery.hpp
@@ -38,18 +38,20 @@ namespace ifm3d
   /** @brief It signalize that network device is not in same subnet. */
   constexpr uint32_t BCAST_FLAG_WRONGSUBNET = 0x0001;
 
-  /** @brief It signalize that network device interface ip address is set via dhcp. */
+  /** @brief It signalize that network device interface ip address is set via
+   * dhcp. */
   constexpr uint32_t BCAST_FLAG_BYDHCP = 0x0002;
 
-  /** @brief It signalize that network device interface ip address is temporary. */
+  /** @brief It signalize that network device interface ip address is
+   * temporary. */
   constexpr uint32_t BCAST_FLAG_ISTEMPORARY = 0x0004;
 
   /** @brief Reserved. */
   constexpr uint32_t BCAST_FLAG_WITHPRGTYPE = 0x8000;
 
-
   /** @brief Broadcast request packet structure. */
-  struct BcastRequest {
+  struct BcastRequest
+  {
     /** @brief Default magic number 0x1020EFCF. */
     const uint32_t magic;
     /** @brief Port to send reply to. */
@@ -58,12 +60,16 @@ namespace ifm3d
     /** @brief Unused. */
     const uint16_t reserved;
 
-    BcastRequest():magic(htonl(BCAST_MAGIC_REQUEST)), reply_port(htons(BCAST_DEFAULT_PORT)), reserved(0)
-    {}
+    BcastRequest()
+      : magic(htonl(BCAST_MAGIC_REQUEST)),
+        reply_port(htons(BCAST_DEFAULT_PORT)),
+        reserved(0)
+    { }
   };
 
   /** @brief Broadcast reply packet structure. */
- struct BcastReply {
+  struct BcastReply
+  {
     /** @brief Default magic number 0x19111981. */
     uint32_t magic;
 
@@ -95,18 +101,19 @@ namespace ifm3d
     uint32_t reserved3;
 
     /** @brief Network device interface mac address. */
-    uint8_t  mac[6];
+    uint8_t mac[6];
 
     /** @brief Network device flags. */
     uint16_t flags;
 
     /** @brief Network device hostname */
-    char     name[64];
+    char name[64];
 
     /** @brief device name defined by the user */
-    char     devicename[256];
+    char devicename[256];
 
-    void NetworktoHost()
+    void
+    NetworktoHost()
     {
       ip_address = ntohl(ip_address);
       ip_gateway = ntohl(ip_gateway);
@@ -116,340 +123,399 @@ namespace ifm3d
       device_id = ntohs(device_id);
       vendor_id = ntohs(vendor_id);
     }
- };
+  };
 
- namespace
- {
-   inline const std::string address2Str(const uint32_t addr)
-   {
-     std::stringstream ss;
-     ss << ((addr >> 24) & 0xff) << "."
-        << ((addr >> 16) & 0xff) << "."
-        << ((addr >> 8) & 0xff)  << "."
-        << ((addr >> 0) & 0xff);
-     return ss.str();
-   }
-
-   inline const std::string uint8Mac2macStr(uint8_t *mac, size_t size = 6)
-   {
-     std::stringstream ss;
-     auto converttoHexandAppend = [&](const uint8_t value)
-     {
-       ss << std::hex << std::setfill('0') << std::setw(2) << int(value);
-     };
-
-     for (int i = 0; i < size - 1; i++)
-     {
-       converttoHexandAppend(mac[i]);
-       ss << "::";
-     }
-     converttoHexandAppend(mac[size - 1]);
-     return ss.str();
-   }
- }
-
- struct IFMNetworkDevice
- {
-   const std::string ip_address;
-   const std::string mac;
-   const std::string subnet;
-   const std::string gateway;
-   const uint16_t port;
-   /** @brief the device gives some additional information via those flags */
-   const uint16_t flags;
-   const std::string hostname;
-   /** @brief IP-address of local-interface on which the NetDevice was found */
-   const std::string found_via;
-   const std::string device_name;
-   const uint16_t vendor_id;
-   const uint16_t device_id;
-
-   IFMNetworkDevice(const BcastReply& reply, const std::string& interface)
-     : ip_address(address2Str(reply.ip_address))
-     , gateway(address2Str(reply.ip_gateway))
-     , subnet(address2Str(reply.ip_netmask))
-     , mac(uint8Mac2macStr((uint8_t*)reply.mac))
-     , port(reply.port)
-     , flags(reply.flags)
-     , device_id(reply.device_id)
-     , vendor_id(reply.vendor_id)
-     , hostname(std::string(reply.name))
-     , device_name(std::string(reply.devicename))
-     , found_via(interface)
-   {}
-
-   void Display()
-   {
-     std::cout << std::endl;
-     std::cout << "ip-address : " << ip_address << std::endl;
-     std::cout << "gateway : " << gateway << std::endl;
-     std::cout << "subnet : " << subnet << std::endl;
-     std::cout << "mac : " << mac << std::endl;
-     std::cout << "port : " << port << std::endl;
-     std::cout << "flags : " << flags << std::endl;
-     std::cout << "device-id : " << device_id << std::endl;
-     std::cout << "vendor_id : " << vendor_id << std::endl;
-     std::cout << "hostname : " << hostname << std::endl;
-     std::cout << "device-name : " << device_name << std::endl;
-     std::cout << "found_via : " << found_via << std::endl;
-   }
- };
-
- constexpr size_t MAX_UDP_PACKET_SIZE = 65535;
- using Data = std::vector<unsigned char>;
-
- class UDPConnection : public std::enable_shared_from_this<UDPConnection> {
- public:
-   UDPConnection(asio::io_context& context, asio::ip::udp::endpoint& local_endpoint)
-     :socket(context, local_endpoint)
-     ,timer(context)
-   {
-     data.resize(MAX_UDP_PACKET_SIZE);
-     socket.set_option(
-       asio::ip::udp::socket::reuse_address(true));
-     asio::socket_base::broadcast option(true);
-     socket.set_option(option);
+  namespace
+  {
+    inline const std::string
+    address2Str(const uint32_t addr)
+    {
+      std::stringstream ss;
+      ss << ((addr >> 24) & 0xff) << "." << ((addr >> 16) & 0xff) << "."
+         << ((addr >> 8) & 0xff) << "." << ((addr >> 0) & 0xff);
+      return ss.str();
     }
 
-   void Send(const Data &data, asio::ip::udp::endpoint remote_endpoint)
-   {
-     socket.async_send_to(asio::buffer((char*)data.data(), data.size()), remote_endpoint,
-       std::bind(&UDPConnection::handle_send, this,
-         std::placeholders::_1,
-         std::placeholders::_2));
-   }
+    inline const std::string
+    uint8Mac2macStr(uint8_t* mac, size_t size = 6)
+    {
+      std::stringstream ss;
+      auto converttoHexandAppend = [&](const uint8_t value) {
+        ss << std::hex << std::setfill('0') << std::setw(2) << int(value);
+      };
 
-   void GrabData()
-   {
-     recieve();
-     check_timeout();
-   }
+      for (int i = 0; i < size - 1; i++)
+        {
+          converttoHexandAppend(mac[i]);
+          ss << "::";
+        }
+      converttoHexandAppend(mac[size - 1]);
+      return ss.str();
+    }
+  }
 
-   void RegisterOnRecieve(std::function<void(asio::ip::udp::endpoint&, Data, size_t)> on_recvieve)
-   {
-     this->on_recieve = on_recvieve;
-   }
-   void RegisterOnClose(std::function<void(std::shared_ptr<UDPConnection>)> on_close)
-   {
-     this->on_close = on_close;
-   }
+  struct IFMNetworkDevice
+  {
+    const std::string ip_address;
+    const std::string mac;
+    const std::string subnet;
+    const std::string gateway;
+    const uint16_t port;
+    /** @brief the device gives some additional information via those flags */
+    const uint16_t flags;
+    const std::string hostname;
+    /** @brief IP-address of local-interface on which the NetDevice was found
+     */
+    const std::string found_via;
+    const std::string device_name;
+    const uint16_t vendor_id;
+    const uint16_t device_id;
 
- protected:
-   void handle_send(const asio::error_code& error,
-     std::size_t /*bytes_transferred*/)
-   {
-     /* udp we send and forget so nothing to do in this callback*/
-   }
+    IFMNetworkDevice(const BcastReply& reply, const std::string& interface)
+      : ip_address(address2Str(reply.ip_address)),
+        gateway(address2Str(reply.ip_gateway)),
+        subnet(address2Str(reply.ip_netmask)),
+        mac(uint8Mac2macStr((uint8_t*)reply.mac)),
+        port(reply.port),
+        flags(reply.flags),
+        device_id(reply.device_id),
+        vendor_id(reply.vendor_id),
+        hostname(std::string(reply.name)),
+        device_name(std::string(reply.devicename)),
+        found_via(interface)
+    { }
 
-   void recieve()
-   {
-     //start the timer for timeout of 3 secs, if data didnot come
-     // with timeout then connection will be closed and notified to parent
-     timer.expires_from_now(std::chrono::milliseconds(3000));
-     data.clear();
-     data.resize(MAX_UDP_PACKET_SIZE);
+    void
+    Display()
+    {
+      std::cout << std::endl;
+      std::cout << "ip-address : " << ip_address << std::endl;
+      std::cout << "gateway : " << gateway << std::endl;
+      std::cout << "subnet : " << subnet << std::endl;
+      std::cout << "mac : " << mac << std::endl;
+      std::cout << "port : " << port << std::endl;
+      std::cout << "flags : " << flags << std::endl;
+      std::cout << "device-id : " << device_id << std::endl;
+      std::cout << "vendor_id : " << vendor_id << std::endl;
+      std::cout << "hostname : " << hostname << std::endl;
+      std::cout << "device-name : " << device_name << std::endl;
+      std::cout << "found_via : " << found_via << std::endl;
+    }
+  };
 
-     asio::ip::udp::endpoint sender_endpoint;
-     socket.async_receive_from(
-       asio::buffer(data.data(), data.size()), sender_endpoint,
-       std::bind(&UDPConnection::handle_receive, this, socket.local_endpoint(),
-         std::placeholders::_1,
-         std::placeholders::_2));
-   }
+  constexpr size_t MAX_UDP_PACKET_SIZE = 65535;
+  using Data = std::vector<unsigned char>;
+  constexpr size_t TIMEOUT_FOR_EACH_SEARCH_IN_MS = 3000;
+  /*@brief This class provides an interface  for send and receive
+   * over UDP socket.
+   **/
+  class UDPConnection : public std::enable_shared_from_this<UDPConnection>
+  {
+  public:
+    UDPConnection(asio::io_context& context,
+                  asio::ip::udp::endpoint& local_endpoint)
+      : socket(context, local_endpoint),
+        timer(context)
+    {
+      data.resize(MAX_UDP_PACKET_SIZE);
+      socket.set_option(asio::ip::udp::socket::reuse_address(true));
+      asio::socket_base::broadcast option(true);
+      socket.set_option(option);
+    }
+    /*@brief sends the data on the endpoint
+     *@param data Data to be send on endpoint
+     *@param Endpoint to send the data.
+     **/
+    void
+    Send(const Data& data, asio::ip::udp::endpoint remote_endpoint)
+    {
+      socket.async_send_to(asio::buffer((char*)data.data(), data.size()),
+                           remote_endpoint,
+                           std::bind(&UDPConnection::handle_send,
+                                     this,
+                                     std::placeholders::_1,
+                                     std::placeholders::_2));
+    }
+    /*@brief grab data on the local endpoint till the timeout occur*/
+    void
+    GrabData()
+    {
+      recieve();
+      check_timeout();
+    }
 
-   void handle_receive(asio::ip::udp::endpoint& sender, const asio::error_code& error, size_t bytes_transferred)
-   {
-     if (error)
-     {
-       return;
-     }
-     on_recieve(sender, data, bytes_transferred);
-     recieve();
-   }
+    /*@brief provides interface to register callback on data received */
+    void
+    RegisterOnRecieve(
+      std::function<void(asio::ip::udp::endpoint&, Data, size_t)> on_recvieve)
+    {
+      this->on_recieve = on_recvieve;
+    }
 
-   void close()
-   {
-     socket.close();
-     on_close(shared_from_this());
-   }
-   
-   void check_timeout()
-   {
-     if (timer.expires_at() <= std::chrono::system_clock::now())
-     {
-       close();
-     }
-     else
-     {
-       timer.async_wait(std::bind(&UDPConnection::check_timeout, this));
-     }
-   }
+    /*@brief provides interface to register callback on timeout or for any error*/
+    void
+    RegisterOnClose(
+      std::function<void(std::shared_ptr<UDPConnection>)> on_close)
+    {
+      this->on_close = on_close;
+    }
 
- private:
-   asio::ip::udp::socket socket;
-   asio::system_timer timer;
-   std::mutex mutex;
-   Data data;
-   std::function<void(asio::ip::udp::endpoint&, Data, size_t)> on_recieve;
-   std::function<void(std::shared_ptr<UDPConnection>)> on_close;
- };
+  protected:
+    void
+    handle_send(const asio::error_code& error,
+                std::size_t /*bytes_transferred*/)
+    {
+      /* udp we send and forget so nothing to do in this callback*/
+    }
 
- const std::map<uint32_t, std::function<size_t(size_t)>> package_validation
- {
-   {BCAST_MAGIC_REQUEST, [](size_t size)-> uint32_t {return sizeof(BcastRequest) - size; }},
-   {BCAST_MAGIC_REPLY, [](size_t size)-> uint32_t {return sizeof(BcastReply) - size; }}
- };
+    void
+    recieve()
+    {
+      /* start the timer for timeout of 3 secs, if data do not come
+         within timeout then connection will be closed and notified to parent */
+      timer.expires_from_now(
+        std::chrono::milliseconds(TIMEOUT_FOR_EACH_SEARCH_IN_MS));
+      data.clear();
+      data.resize(MAX_UDP_PACKET_SIZE);
 
- const unsigned int THREADS_FOR_IO_OPERATIONS = 3;
+      asio::ip::udp::endpoint sender_endpoint;
+      socket.async_receive_from(asio::buffer(data.data(), data.size()),
+                                sender_endpoint,
+                                std::bind(&UDPConnection::handle_receive,
+                                          this,
+                                          socket.local_endpoint(),
+                                          std::placeholders::_1,
+                                          std::placeholders::_2));
+    }
 
- class IFMDeviceDiscovery
- {
- public:
-   IFMDeviceDiscovery()
-     :work_guard(asio::make_work_guard(io_context))
-   {
-     for (auto i = 0; i < THREADS_FOR_IO_OPERATIONS; i++)
-     {
-       thread_pool.push_back(std::thread(std::bind([&] { io_context.run(); })));
-     }
-   }
-   IFMDeviceDiscovery(IFMDeviceDiscovery&&) = delete;
-   IFMDeviceDiscovery& operator=(IFMDeviceDiscovery&&) = delete;
-   IFMDeviceDiscovery(IFMDeviceDiscovery&) = delete;
-   IFMDeviceDiscovery& operator=(IFMDeviceDiscovery&) = delete;
+    void
+    handle_receive(asio::ip::udp::endpoint& sender,
+                   const asio::error_code& error,
+                   size_t bytes_transferred)
+    {
+      if (error)
+        {
+          return;
+        }
+      on_recieve(sender, data, bytes_transferred);
+      recieve();
+    }
 
-   std::vector<IFMNetworkDevice> NetworkSearch()
-   {
-     device_list.clear();
-     asio::ip::udp::resolver resolver(io_context);
-     std::string h = asio::ip::host_name();
-     auto re_list = resolver.resolve({ h, "" });
+    void
+    close()
+    {
+      socket.close();
+      // notify the caller through registered callback
+      on_close(shared_from_this());
+    }
 
-     /* Create connection on all interfaces */
-     for (const auto & re : re_list)
-     {
-       asio::ip::udp::endpoint endpoint(asio::ip::address::from_string(re.endpoint().address().to_string()), BCAST_DEFAULT_PORT);
+    void
+    check_timeout()
+    {
+      if (timer.expires_at() <= std::chrono::system_clock::now())
+        {
+          close();
+        }
+      else
+        {
+          timer.async_wait(std::bind(&UDPConnection::check_timeout, this));
+        }
+    }
 
-       auto con = std::make_shared<UDPConnection>(io_context, endpoint);
-       con->RegisterOnRecieve(std::bind(&IFMDeviceDiscovery::on_receive, this, std::placeholders::_1,
-         std::placeholders::_2, std::placeholders::_3));
-       con->RegisterOnClose(std::bind(&IFMDeviceDiscovery::remove_connection, this, std::placeholders::_1));
+  private:
+    asio::ip::udp::socket socket;
+    asio::system_timer timer;
+    std::mutex mutex;
+    Data data;
+    std::function<void(asio::ip::udp::endpoint&, Data, size_t)> on_recieve;
+    std::function<void(std::shared_ptr<UDPConnection>)> on_close;
+  };
 
-       connection_list.push_back(con);
+  const std::map<uint32_t, std::function<size_t(size_t)>> package_validation{
+    {BCAST_MAGIC_REQUEST,
+     [](size_t size) -> uint32_t { return sizeof(BcastRequest) - size; }},
+    {BCAST_MAGIC_REPLY,
+     [](size_t size) -> uint32_t { return sizeof(BcastReply) - size; }}};
 
-     }
-     // broadcast ifm discovery request on all interfaces
-     broadcast();
-     // call getDevice List
-     auto devices = getDeviceList();
+  const unsigned int THREADS_FOR_IO_OPERATIONS = 3;
 
-     //stop the io_context after getting list
-     io_context.stop();
+  class IFMDeviceDiscovery
+  {
+  public:
+    IFMDeviceDiscovery() : work_guard(asio::make_work_guard(io_context))
+    {
+      for (auto i = 0; i < THREADS_FOR_IO_OPERATIONS; i++)
+        {
+          thread_pool.push_back(
+            std::thread(std::bind([&] { io_context.run(); })));
+        }
+    }
+    IFMDeviceDiscovery(IFMDeviceDiscovery&&) = delete;
+    IFMDeviceDiscovery& operator=(IFMDeviceDiscovery&&) = delete;
+    IFMDeviceDiscovery(IFMDeviceDiscovery&) = delete;
+    IFMDeviceDiscovery& operator=(IFMDeviceDiscovery&) = delete;
 
-     // wait for all threads to complete
-     for (std::thread& thread : thread_pool)
-     {
-       if (thread.joinable())
-       {
-         thread.join();
-       }
-     }
+    std::vector<IFMNetworkDevice>
+    NetworkSearch()
+    {
+      device_list.clear();
+      asio::ip::udp::resolver resolver(io_context);
+      std::string h = asio::ip::host_name();
+      auto re_list = resolver.resolve({h, ""});
 
-     return devices;
-   }
+      /* Create connection on all interfaces */
+      for (const auto& re : re_list)
+        {
+          asio::ip::udp::endpoint endpoint(
+            asio::ip::address::from_string(
+              re.endpoint().address().to_string()),
+            BCAST_DEFAULT_PORT);
 
- private:
-   void broadcast()
-   {
-     const BcastRequest request;
-     Data data;
-     data.resize(sizeof(BcastRequest));
-     std::memcpy(data.data(), &request, sizeof(BcastRequest));
-     // create a broadcast remote endpoints
-     asio::ip::udp::endpoint remote_endpoint = asio::ip::udp::endpoint(asio::ip::address_v4::broadcast(), BCAST_DEFAULT_PORT);
-     //send BCAST_REQUEST on all interfaces
-     for (const auto & con : connection_list)
-     {
-       con->Send(data, remote_endpoint);
-     }
-   }
-   //@brief checks the data for corresponding request on magic entry.
-   std::tuple<bool, uint32_t, size_t> is_response_complete(const Data& data, const size_t byte_recv)
-   {
-     // timer.cancel_one();
-     uint32_t magic_value = 0;
-     std::memcpy(&magic_value, data.data(), sizeof(uint32_t));
+          auto con = std::make_shared<UDPConnection>(io_context, endpoint);
+          con->RegisterOnRecieve(std::bind(&IFMDeviceDiscovery::on_receive,
+                                           this,
+                                           std::placeholders::_1,
+                                           std::placeholders::_2,
+                                           std::placeholders::_3));
+          con->RegisterOnClose(
+            std::bind(&IFMDeviceDiscovery::remove_connection,
+                      this,
+                      std::placeholders::_1));
 
-     magic_value = ntohl(magic_value);
+          connection_list.push_back(con);
+        }
+      // broadcast ifm discovery request on all interfaces
+      broadcast();
+      // call getDevice List
+      auto devices = getDeviceList();
 
-     if (package_validation.find(magic_value) != package_validation.end())
-     {
-       auto required_length = package_validation.at(magic_value)(byte_recv);
-       return std::make_tuple(required_length == 0, magic_value, required_length);
-     }
-     else
-     {
-       std::cout << "invalid response" << std::endl;
-     }
-   }
+      // stop the io_context after getting list
+      io_context.stop();
 
-   void on_receive(asio::ip::udp::endpoint& sender, Data data, size_t bytes_transferred)
-   {
-     bool iscomplete;
-     size_t required;
-     uint32_t magic_value;
-     std::tie(iscomplete, magic_value, required) = is_response_complete(data, bytes_transferred);
+      // wait for all threads to complete
+      for (std::thread& thread : thread_pool)
+        {
+          if (thread.joinable())
+            {
+              thread.join();
+            }
+        }
 
-     if (iscomplete)
-     {
-       if (magic_value == BCAST_MAGIC_REPLY)
-       {
-         BcastReply reply;
-         std::memcpy(&reply, data.data(), sizeof(BcastReply));
-         reply.NetworktoHost();
-         IFMNetworkDevice ifm_device(reply, sender.address().to_string());
-         std::lock_guard<std::mutex> lock(device_list_lock);
-         device_list.push_back(ifm_device);
-       }
-     }
-     else
-     {
-       std::cout << "discard this packet";
-     }
-   }
+      return devices;
+    }
 
-   std::vector<IFMNetworkDevice> getDeviceList()
-   {
-     /* Grab device BCAST_REPLY on all Connections */
-     for (auto con : connection_list)
-     {
-       con->GrabData();
-     }
+  private:
+    /* @brief broadcast the Bcast request on all interfaces*/
+    void
+    broadcast()
+    {
+      const BcastRequest request;
+      Data data;
+      data.resize(sizeof(BcastRequest));
+      std::memcpy(data.data(), &request, sizeof(BcastRequest));
+      // create a broadcast remote endpoints
+      asio::ip::udp::endpoint remote_endpoint =
+        asio::ip::udp::endpoint(asio::ip::address_v4::broadcast(),
+                                BCAST_DEFAULT_PORT);
+      // send BCAST_REQUEST on all interfaces
+      for (const auto& con : connection_list)
+        {
+          con->Send(data, remote_endpoint);
+        }
+    }
+    /*@brief checks the data for corresponding request on magic entry. */
+    std::tuple<bool, uint32_t, size_t>
+    is_response_complete(const Data& data, const size_t byte_recv)
+    {
+      // timer.cancel_one();
+      uint32_t magic_value = 0;
+      std::memcpy(&magic_value, data.data(), sizeof(uint32_t));
 
-     std::unique_lock<std::mutex> lock_to_complete(mutex);
-     cv.wait(lock_to_complete, [&] {return connection_list.size() == 0; });
-     return  device_list;
-   }
+      magic_value = ntohl(magic_value);
 
-   void remove_connection(std::shared_ptr< UDPConnection> con)
-   {
-     std::lock_guard<std::mutex> lock(connection_pool_lock);
-     connection_list.erase(
-       std::remove(std::begin(connection_list), std::end(connection_list), con),
-       std::end(connection_list));
-     cv.notify_one();
-   }
+      if (package_validation.find(magic_value) != package_validation.end())
+        {
+          auto required_length = package_validation.at(magic_value)(byte_recv);
+          return std::make_tuple(required_length == 0,
+                                 magic_value,
+                                 required_length);
+        }
+      else
+        {
+          /* Todo : use logger*/
+          std::cout << "invalid response packet" << std::endl;
+        }
+    }
+    /*@brief Handles the data packet, parse the reply, creates the
+     * IFMBetworkDevice  */
+    void
+    on_receive(asio::ip::udp::endpoint& sender,
+               Data data,
+               size_t bytes_transferred)
+    {
+      bool iscomplete;
+      size_t required;
+      uint32_t magic_value;
+      std::tie(iscomplete, magic_value, required) =
+        is_response_complete(data, bytes_transferred);
 
-   asio::io_context io_context;
-   asio::executor_work_guard<asio::io_service::executor_type> work_guard;
-   std::mutex mutex;
-   std::condition_variable cv;
-   std::vector < std::shared_ptr<UDPConnection>> connection_list;
-   std::vector<ifm3d::IFMNetworkDevice> device_list;
-   std::vector<std::thread> thread_pool;
-   std::mutex connection_pool_lock;
-   std::mutex device_list_lock;
- };
+      if (iscomplete)
+        {
+          if (magic_value == BCAST_MAGIC_REPLY)
+            {
+              BcastReply reply;
+              std::memcpy(&reply, data.data(), sizeof(BcastReply));
+              reply.NetworktoHost();
+              IFMNetworkDevice ifm_device(reply, sender.address().to_string());
+              std::lock_guard<std::mutex> lock(device_list_lock);
+              device_list.push_back(ifm_device);
+            }
+        }
+      else
+        {
+          std::cout << "discard this packet";
+        }
+    }
+    /* return the discovered device list*/
+    std::vector<IFMNetworkDevice>
+    getDeviceList()
+    {
+      /* Grab device BCAST_REPLY on all Connections */
+      for (auto con : connection_list)
+        {
+          con->GrabData();
+        }
+
+      /*block the main thread till the search is complete
+      which is the condition when all the connection on
+      interface is removed from connection pool */
+      std::unique_lock<std::mutex> lock_to_complete(mutex);
+      cv.wait(lock_to_complete, [&] { return connection_list.size() == 0; });
+      return device_list;
+    }
+
+    /*@brief remove the connection from the connection list */
+    void
+    remove_connection(std::shared_ptr<UDPConnection> con)
+    {
+      std::lock_guard<std::mutex> lock(connection_pool_lock);
+      connection_list.erase(std::remove(std::begin(connection_list),
+                                        std::end(connection_list),
+                                        con),
+                            std::end(connection_list));
+      cv.notify_one();
+    }
+
+    asio::io_context io_context;
+    asio::executor_work_guard<asio::io_service::executor_type> work_guard;
+    std::mutex mutex;
+    std::condition_variable cv;
+    std::vector<std::shared_ptr<UDPConnection>> connection_list;
+    std::vector<ifm3d::IFMNetworkDevice> device_list;
+    std::vector<std::thread> thread_pool;
+    std::mutex connection_pool_lock;
+    std::mutex device_list_lock;
+  };
 }
 #endif // IFM3D_CAMERA_DISCOVERY_HPP
 
@@ -462,9 +528,9 @@ int main()
   auto devices = ifm_discovery.NetworkSearch();
 
   for (auto & device : devices)
-  {
-    device.Display();
-  }
+    {
+      device.Display();
+    }
 }
 
 #endif

--- a/modules/camera/src/libifm3d_camera/discovery.hpp
+++ b/modules/camera/src/libifm3d_camera/discovery.hpp
@@ -29,6 +29,9 @@ namespace ifm3d
   /** Broadcast reply magic number. */
   constexpr uint32_t BCAST_MAGIC_REPLY = 0x19111981;
 
+  /** @brief Broadcast ipchange magic number. */
+  constexpr uint32_t BCAST_MAGIC_IPCHANGE = 0x1020efce;
+
   /** Broadcast request magic number. */
   constexpr uint32_t BCAST_MAGIC_REQUEST = 0x1020efcf;
 
@@ -132,12 +135,74 @@ namespace ifm3d
       for (int i = 0; i < size - 1; i++)
         {
           converttoHexandAppend(mac[i]);
-          ss << "::";
+          ss << ":";
         }
       converttoHexandAppend(mac[size - 1]);
       return ss.str();
     }
+
+    uint32_t
+    toAddress(std::string ipadd)
+    {
+      std::stringstream ss(ipadd);
+      int oct1, oct2, oct3, oct4 = 0;
+      char dot;
+      ss >> oct1 >> dot >> oct2 >> dot >> oct3 >> dot >> oct4;
+
+      uint32_t result = (uint32_t)oct1 << 24 | (uint32_t)oct2 << 16 |
+                        (uint32_t)oct3 << 8 | (uint32_t)oct4;
+
+      return result;
+    }
+
+    void
+    strMac2uintmac(const std::string& mac, uint8_t* mac_array, size_t size)
+    {
+      std::stringstream ss(mac);
+      char double_colon;
+      int value;
+      ss >> std::hex;
+      for (int i = 0; i < size - 1; i++)
+        {
+          ss >> value >> double_colon;
+          mac_array[i] = value;
+        }
+      ss >> value;
+      mac_array[size - 1] = value;
+    }
   }
+
+  /** @brief Broadcast ipchange packet structure. */
+  struct BcastIPchange
+  {
+    /** @brief Default magic number 0x1020efce. */
+    uint32_t magic;
+
+    /** @brief Port to send reply to. */
+    uint16_t replyPort;
+
+    /** @brief Unused. */
+    uint16_t reserved1;
+
+    /** @brief Temporary ip address that should be set. */
+    uint32_t tempIP;
+
+    /** @brief Unused. */
+    uint16_t reserved2;
+
+    /** @brief Mac address of interface to change. */
+    uint8_t mac[6];
+
+    BcastIPchange(const std::string& device_mac, const std::string& temp_ip)
+      : magic(htonl(BCAST_MAGIC_IPCHANGE)),
+        replyPort(htons(BCAST_DEFAULT_PORT)),
+        reserved1(0),
+        tempIP(htonl(toAddress(temp_ip))),
+        reserved2(0)
+    {
+      strMac2uintmac(device_mac, mac, 6);
+    }
+  };
 
   IFMNetworkDevice::IFMNetworkDevice(
     Data& data,
@@ -207,12 +272,14 @@ namespace ifm3d
     return device_name_;
   }
 
-  uint16_t IFMNetworkDevice::GetVendorId() const
+  uint16_t
+  IFMNetworkDevice::GetVendorId() const
   {
     return vendor_id_;
   }
 
-  uint16_t IFMNetworkDevice::GetDeviceId() const
+  uint16_t
+  IFMNetworkDevice::GetDeviceId() const
   {
     return device_id_;
   }
@@ -372,7 +439,9 @@ namespace ifm3d
     {BCAST_MAGIC_REQUEST,
      [](size_t size) -> uint32_t { return sizeof(BcastRequest) - size; }},
     {BCAST_MAGIC_REPLY,
-     [](size_t size) -> uint32_t { return sizeof(BcastReply) - size; }}};
+     [](size_t size) -> uint32_t { return sizeof(BcastReply) - size; }},
+    {BCAST_MAGIC_IPCHANGE,
+     [](size_t size) -> uint32_t { return sizeof(BcastIPchange) - size; }}};
 
   const unsigned int THREADS_FOR_IO_OPERATIONS = 3;
 
@@ -386,16 +455,6 @@ namespace ifm3d
           thread_pool_.push_back(
             std::thread(std::bind([&] { io_context_.run(); })));
         }
-    }
-    IFMDeviceDiscovery(IFMDeviceDiscovery&&) = delete;
-    IFMDeviceDiscovery& operator=(IFMDeviceDiscovery&&) = delete;
-    IFMDeviceDiscovery(IFMDeviceDiscovery&) = delete;
-    IFMDeviceDiscovery& operator=(IFMDeviceDiscovery&) = delete;
-
-    std::vector<IFMNetworkDevice>
-    NetworkSearch()
-    {
-      device_list_.clear();
 
       /* Creating universal listener udp connection */
       asio::ip::udp::endpoint endpoint(asio::ip::address_v4::any(),
@@ -412,31 +471,74 @@ namespace ifm3d
                                      std::placeholders::_1));
 
       connection_list_.push_back(con);
+    }
 
+    ~IFMDeviceDiscovery()
+    {
+      /* stop the io_context after getting list */
+      io_context_.stop();
+
+      // wait for all threads to complete
+      for (std::thread& thread : thread_pool_)
+        {
+          if (thread.joinable())
+            {
+              thread.join();
+            }
+        }
+    }
+
+    IFMDeviceDiscovery(IFMDeviceDiscovery&&) = delete;
+    IFMDeviceDiscovery& operator=(IFMDeviceDiscovery&&) = delete;
+    IFMDeviceDiscovery(IFMDeviceDiscovery&) = delete;
+    IFMDeviceDiscovery& operator=(IFMDeviceDiscovery&) = delete;
+
+    std::vector<IFMNetworkDevice>
+    SearchDevices()
+    {
       try
         {
-          auto addresses = _GetAllInterfaceAddress();
+          device_list_.clear();
+          // get dall the address
+          auto address = _GetAllInterfaceAddress();
 
-          /* broadcast ifm discovery request on all interfaces */
-          for (const auto& address : addresses)
-            {
-              _BroadcastOnInterface(address);
-            }
+          Data data;
+          const BcastRequest request;
+          data.resize(sizeof(BcastRequest));
+          std::memcpy(data.data(), &request, sizeof(BcastRequest));
+
+          _BroadcastRequest(data, address);
+
           /* get the device list  this will block the thread
-             till all NIC are scanned for devices */
+                till all NIC are scanned for devices */
           auto devices = _GetDeviceList();
+      }
+      catch (std::exception& e)
+        {
+          std::cerr << e.what() << std::endl;
+        }
+      return device_list_;
+    }
 
-          /* stop the io_context after getting list */
-          io_context_.stop();
+    std::vector<IFMNetworkDevice>
+    SetTempIpaddress(const std::string& dev_mac, const std::string& temp_ip)
+    {
+      try
+        {
+          device_list_.clear();
+          // get dall the address
+          auto address = _GetAllInterfaceAddress();
 
-          // wait for all threads to complete
-          for (std::thread& thread : thread_pool_)
-            {
-              if (thread.joinable())
-                {
-                  thread.join();
-                }
-            }
+          Data data;
+          const BcastIPchange request(dev_mac, temp_ip);
+          data.resize(sizeof(BcastIPchange));
+          std::memcpy(data.data(), &request, sizeof(BcastIPchange));
+
+          _BroadcastRequest(data, address);
+
+          /* get the device list  this will block the thread
+                till all NIC are scanned for devices */
+          auto devices = _GetDeviceList();
         }
       catch (std::exception& e)
         {
@@ -444,169 +546,174 @@ namespace ifm3d
         }
       return device_list_;
     }
-  private:
 
-    std::vector<std::string>
-    _GetAllInterfaceAddress()
-    {
-      std::vector<std::string> addresses;
+  void
+  _BroadcastRequest(ifm3d::Data& request, std::vector<std::string>& addresses)
+  {
+    for (const auto& address : addresses)
+      {
+        _BroadcastOnInterface(request, address);
+      }
+  }
+
+private:
+  std::vector<std::string>
+  _GetAllInterfaceAddress()
+  {
+    std::vector<std::string> addresses;
 #ifdef __unix__
-      struct ifaddrs *ifap, *ifa;
-      struct sockaddr_in* sa;
-      char* addr;
+    struct ifaddrs *ifap, *ifa;
+    struct sockaddr_in* sa;
+    char* addr;
 
-      getifaddrs(&ifap);
-      for (ifa = ifap; ifa; ifa = ifa->ifa_next)
-        {
-          if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET)
-            {
-              sa = (struct sockaddr_in*)ifa->ifa_addr;
-              addr = inet_ntoa(sa->sin_addr);
-              std::string ip_address = std::string(addr);
-              addresses.push_back(ip_address);
-            }
-        }
-      freeifaddrs(ifap);
+    getifaddrs(&ifap);
+    for (ifa = ifap; ifa; ifa = ifa->ifa_next)
+      {
+        if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET)
+          {
+            sa = (struct sockaddr_in*)ifa->ifa_addr;
+            addr = inet_ntoa(sa->sin_addr);
+            std::string ip_address = std::string(addr);
+            addresses.push_back(ip_address);
+          }
+      }
+    freeifaddrs(ifap);
 #else
 
-      asio::ip::udp::resolver resolver(io_context_);
-      std::string h = asio::ip::host_name();
-      auto re_list = resolver.resolve({h, ""});
+    asio::ip::udp::resolver resolver(io_context_);
+    std::string h = asio::ip::host_name();
+    auto re_list = resolver.resolve({h, ""});
 
-      for (const auto& re : re_list)
-        {
-          addresses.push_back(re.endpoint().address().to_string());
-        }
+    for (const auto& re : re_list)
+      {
+        addresses.push_back(re.endpoint().address().to_string());
+      }
 #endif
-      return addresses;
-    }
-    /* broadcast the Bcast request on interface*/
-    void
-    _BroadcastOnInterface(std::string interface_ip)
-    {
-      const BcastRequest request;
-      Data data;
-      data.resize(sizeof(BcastRequest));
-      std::memcpy(data.data(), &request, sizeof(BcastRequest));
+    return addresses;
+  }
+  /* broadcast the Bcast request on interface*/
+  void
+  _BroadcastOnInterface(ifm3d::Data& data, std::string interface_ip)
+  {
+    /* create a local endpoints */
+    asio::ip::udp::endpoint local_endpoint =
+      asio::ip::udp::endpoint(asio::ip::address::from_string(interface_ip),
+                              BCAST_DEFAULT_PORT);
 
-      /* create a local endpoints */
-      asio::ip::udp::endpoint local_endpoint =
-        asio::ip::udp::endpoint(asio::ip::address::from_string(interface_ip),
-                                BCAST_DEFAULT_PORT);
+    /** getting the netmask of the interface*/
+    auto netmask = asio::ip::address_v4::netmask(
+      asio::ip::address_v4::from_string(interface_ip));
 
-      /** getting the netmask of the interface*/
-      auto netmask = asio::ip::address_v4::netmask(
-        asio::ip::address_v4::from_string(interface_ip));
+    /**broadcast of the interface*/
+    auto broadcast_address_of_interface =
+      asio::ip::address_v4::broadcast(
+        asio::ip::address_v4::from_string(interface_ip),
+        netmask)
+        .to_string();
 
-      /**broadcast of the interface*/
-      auto broadcast_address_of_interface =
-        asio::ip::address_v4::broadcast(
-          asio::ip::address_v4::from_string(interface_ip),
-          netmask)
-          .to_string();
+    /* create a local broadcast endpoints */
+    asio::ip::udp::endpoint broadcast_endpoint = asio::ip::udp::endpoint(
+      asio::ip::address::from_string(broadcast_address_of_interface),
+      BCAST_DEFAULT_PORT);
 
-      /* create a local broadcast endpoints */
-      asio::ip::udp::endpoint broadcast_endpoint = asio::ip::udp::endpoint(
-        asio::ip::address::from_string(broadcast_address_of_interface),
-        BCAST_DEFAULT_PORT);
+    auto con = std::make_shared<UDPConnection>(io_context_, local_endpoint);
+    con->RegisterOnReceive(std::bind(&IFMDeviceDiscovery::_OnReceive,
+                                     this,
+                                     std::placeholders::_1,
+                                     std::placeholders::_2,
+                                     std::placeholders::_3));
 
-      auto con = std::make_shared<UDPConnection>(io_context_, local_endpoint);
-      con->RegisterOnReceive(std::bind(&IFMDeviceDiscovery::_OnReceive,
-                                       this,
-                                       std::placeholders::_1,
-                                       std::placeholders::_2,
-                                       std::placeholders::_3));
+    /* send BCAST_REQUEST on all interfaces */
+    con->Send(data, broadcast_endpoint);
 
-      /* send BCAST_REQUEST on all interfaces */
-      con->Send(data, broadcast_endpoint);
+    connection_list_.push_back(con);
+  }
 
-      connection_list_.push_back(con);
-    }
+  /*Checks the data for corresponding request on magic entry. */
+  std::tuple<bool, uint32_t, size_t>
+  _IsResponseComplete(const Data& data, const size_t byte_recv)
+  {
+    uint32_t magic_value = 0;
+    std::memcpy(&magic_value, data.data(), sizeof(uint32_t));
 
-    /*Checks the data for corresponding request on magic entry. */
-    std::tuple<bool, uint32_t, size_t>
-    _IsResponseComplete(const Data& data, const size_t byte_recv)
-    {
-      uint32_t magic_value = 0;
-      std::memcpy(&magic_value, data.data(), sizeof(uint32_t));
+    magic_value = ntohl(magic_value);
 
-      magic_value = ntohl(magic_value);
+    if (package_validation.find(magic_value) != package_validation.end())
+      {
+        auto required_length = package_validation.at(magic_value)(byte_recv);
+        return std::make_tuple(required_length == 0,
+                               magic_value,
+                               required_length);
+      }
+    else
+      {
+        std::cerr << "unknown response for discovery" << std::endl;
+        return {};
+      }
+  }
+  /* Handles the data packet, parse the reply, creates the
+   * IFMNetworkDevice */
+  void
+  _OnReceive(asio::ip::udp::endpoint& sender,
+             Data data,
+             size_t bytes_transferred)
+  {
+    bool iscomplete;
+    size_t required;
+    uint32_t magic_value;
+    std::tie(iscomplete, magic_value, required) =
+      _IsResponseComplete(data, bytes_transferred);
 
-      if (package_validation.find(magic_value) != package_validation.end())
-        {
-          auto required_length = package_validation.at(magic_value)(byte_recv);
-          return std::make_tuple(required_length == 0,
-                                 magic_value,
-                                 required_length);
-        }
-      else
-        {
-          std::cerr << "unknown response for discovery" << std::endl;
-          return {};
-        }
-    }
-    /* Handles the data packet, parse the reply, creates the
-     * IFMNetworkDevice */
-    void
-    _OnReceive(asio::ip::udp::endpoint& sender,
-               Data data,
-               size_t bytes_transferred)
-    {
-      bool iscomplete;
-      size_t required;
-      uint32_t magic_value;
-      std::tie(iscomplete, magic_value, required) =
-        _IsResponseComplete(data, bytes_transferred);
+    if (iscomplete)
+      {
+        if (magic_value == BCAST_MAGIC_REPLY)
+          {
+            IFMNetworkDevice ifm_device(data, sender.address().to_string());
+            std::lock_guard<std::mutex> lock(device_list_lock_);
+            device_list_.push_back(ifm_device);
+          }
+      }
+  }
 
-      if (iscomplete)
-        {
-          if (magic_value == BCAST_MAGIC_REPLY)
-            {
-              IFMNetworkDevice ifm_device(data, sender.address().to_string());
-              std::lock_guard<std::mutex> lock(device_list_lock_);
-              device_list_.push_back(ifm_device);
-            }
-        }
-    }
-    /* return the discovered device list*/
-    std::vector<IFMNetworkDevice>
-    _GetDeviceList()
-    {
-      /** start grab on universal brodcast socket*/
-      connection_list_[0]->GrabData();
-      /*block the main thread till the search is complete
-      which is the condition when all the there is no respone on any interface 
-      for more than  TIMEOUT_FOR_EACH_SEARCH_IN_MS*/
-      std::unique_lock<std::mutex> lock_to_complete(con_mutex_);
-      cv_.wait(lock_to_complete, [&] { return connection_list_.size() == 0; });
-      return device_list_;
-    }
+  /* return the discovered device list*/
+  std::vector<IFMNetworkDevice>
+  _GetDeviceList()
+  {
+    /** start grab on universal brodcast socket*/
+    connection_list_[0]->GrabData();
+    /*block the main thread till the search is complete
+    which is the condition when all the there is no respone on any interface
+    for more than  TIMEOUT_FOR_EACH_SEARCH_IN_MS*/
+    std::unique_lock<std::mutex> lock_to_complete(con_mutex_);
+    cv_.wait(lock_to_complete, [&] { return connection_list_.size() == 0; });
+    return device_list_;
+  }
 
-    /* remove the connection from the connection list */
-    void
-    _RemoveConnection(std::shared_ptr<UDPConnection> con)
-    {
-      std::lock_guard<std::mutex> lock(con_mutex_);
-      connection_list_.erase(std::remove(std::begin(connection_list_),
-                                         std::end(connection_list_),
-                                         con),
-                             std::end(connection_list_));
-      for (const auto& con : connection_list_)
-        {
-          con->Close();
-        }
-      connection_list_.resize(0);
-      cv_.notify_one();
-    }
+  /* remove the connection from the connection list */
+  void
+  _RemoveConnection(std::shared_ptr<UDPConnection> con)
+  {
+    std::lock_guard<std::mutex> lock(con_mutex_);
+    connection_list_.erase(std::remove(std::begin(connection_list_),
+                                       std::end(connection_list_),
+                                       con),
+                           std::end(connection_list_));
+    for (const auto& con : connection_list_)
+      {
+        con->Close();
+      }
+    connection_list_.resize(0);
+    cv_.notify_one();
+  }
 
-    asio::io_context io_context_;
-    asio::executor_work_guard<asio::io_service::executor_type> work_guard_;
-    std::mutex con_mutex_;
-    std::condition_variable cv_;
-    std::vector<std::shared_ptr<UDPConnection>> connection_list_;
-    std::vector<ifm3d::IFMNetworkDevice> device_list_;
-    std::vector<std::thread> thread_pool_;
-    std::mutex device_list_lock_;
-  };
+  asio::io_context io_context_;
+  asio::executor_work_guard<asio::io_service::executor_type> work_guard_;
+  std::mutex con_mutex_;
+  std::condition_variable cv_;
+  std::vector<std::shared_ptr<UDPConnection>> connection_list_;
+  std::vector<ifm3d::IFMNetworkDevice> device_list_;
+  std::vector<std::thread> thread_pool_;
+  std::mutex device_list_lock_;
+};
 }
 #endif // IFM3D_CAMERA_DISCOVERY_HPP

--- a/modules/camera/src/libifm3d_camera/discovery.hpp
+++ b/modules/camera/src/libifm3d_camera/discovery.hpp
@@ -51,10 +51,9 @@ namespace ifm3d
   /** @brief Broadcast request packet structure. */
   struct BcastRequest {
     /** @brief Default magic number 0x1020EFCF. */
-    const uint32_t magic;// = htonl(BCAST_MAGIC_REQUEST);
-
+    const uint32_t magic;
     /** @brief Port to send reply to. */
-    const uint16_t reply_port;// = htonl(BCAST_DEFAULT_PORT);
+    const uint16_t reply_port;
 
     /** @brief Unused. */
     const uint16_t reserved;
@@ -118,5 +117,83 @@ namespace ifm3d
       vendor_id = ntohs(vendor_id);
     }
  };
+
+ namespace
+ {
+   inline const std::string address2Str(const uint32_t addr)
+   {
+     std::stringstream ss;
+     ss << ((addr >> 24) & 0xff) << "."
+        << ((addr >> 16) & 0xff) << "."
+        << ((addr >> 8) & 0xff)  << "."
+        << ((addr >> 0) & 0xff);
+     return ss.str();
+   }
+
+   inline const std::string uint8Mac2macStr(uint8_t *mac, size_t size = 6)
+   {
+     std::stringstream ss;
+     auto converttoHexandAppend = [&](const uint8_t value)
+     {
+       ss << std::hex << std::setfill('0') << std::setw(2) << int(value);
+     };
+
+     for (int i = 0; i < size - 1; i++)
+     {
+       converttoHexandAppend(mac[i]);
+       ss << "::";
+     }
+     converttoHexandAppend(mac[size - 1]);
+     return ss.str();
+   }
+ }
+
+ struct IFMNetworkDevice
+ {
+   const std::string ip_address;
+   const std::string mac;
+   const std::string subnet;
+   const std::string gateway;
+   const uint16_t port;
+   /** @brief the device gives some additional information via those flags */
+   const uint16_t flags;
+   const std::string hostname;
+   /** @brief IP-address of local-interface on which the NetDevice was found */
+   const std::string found_via;
+   const std::string device_name;
+   const uint16_t vendor_id;
+   const uint16_t device_id;
+
+   IFMNetworkDevice(const BcastReply& reply, const std::string& interface)
+     : ip_address(address2Str(reply.ip_address))
+     , gateway(address2Str(reply.ip_gateway))
+     , subnet(address2Str(reply.ip_netmask))
+     , mac(uint8Mac2macStr((uint8_t*)reply.mac))
+     , port(reply.port)
+     , flags(reply.flags)
+     , device_id(reply.device_id)
+     , vendor_id(reply.vendor_id)
+     , hostname(std::string(reply.name))
+     , device_name(std::string(reply.devicename))
+     , found_via(interface)
+   {}
+
+   void Display()
+   {
+     std::cout << std::endl;
+     std::cout << "ip-address : " << ip_address << std::endl;
+     std::cout << "gateway : " << gateway << std::endl;
+     std::cout << "subnet : " << subnet << std::endl;
+     std::cout << "mac : " << mac << std::endl;
+     std::cout << "port : " << port << std::endl;
+     std::cout << "flags : " << flags << std::endl;
+     std::cout << "device-id : " << device_id << std::endl;
+     std::cout << "vendor_id : " << vendor_id << std::endl;
+     std::cout << "hostname : " << hostname << std::endl;
+     std::cout << "device-name : " << device_name << std::endl;
+     std::cout << "found_via : " << found_via << std::endl;
+   }
+ };
+
 }
 #endif // IFM3D_CAMERA_DISCOVERY_HPP

--- a/modules/camera/src/libifm3d_camera/discovery.hpp
+++ b/modules/camera/src/libifm3d_camera/discovery.hpp
@@ -1,19 +1,8 @@
 // -*- c++ -*-
 /*
- * Copyright (C) 2020 ifm electronics, gmbh
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distribted on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (C) 2020 ifm electronic, gmbh
+ * SPDX-License-Identifier: Apache-2.0
  */
-
 #ifndef IFM3D_CAMERA_DISCOVERY_HPP
 #define IFM3D_CAMERA_DISCOVERY_HPP
 
@@ -24,40 +13,48 @@
 #include <iostream>
 #include <iomanip>
 #include <chrono>
+#include <thread>
+#include <ifm3d/camera/ifm_network_device.h>
+#ifdef __unix__
+#  include <arpa/inet.h>
+#  include <sys/socket.h>
+#  include <ifaddrs.h>
+#endif
+
 namespace ifm3d
 {
-  /** @brief Broadcast default port. */
+  /** Broadcast default port. */
   constexpr uint16_t BCAST_DEFAULT_PORT = 3321;
 
-  /** @brief Broadcast reply magic number. */
+  /** Broadcast reply magic number. */
   constexpr uint32_t BCAST_MAGIC_REPLY = 0x19111981;
 
-  /** @brief Broadcast request magic number. */
+  /** Broadcast request magic number. */
   constexpr uint32_t BCAST_MAGIC_REQUEST = 0x1020efcf;
 
-  /** @brief It signalize that network device is not in same subnet. */
+  /** It signalize that network device is not in same subnet. */
   constexpr uint32_t BCAST_FLAG_WRONGSUBNET = 0x0001;
 
-  /** @brief It signalize that network device interface ip address is set via
+  /** It signalize that network device interface ip address is set via
    * dhcp. */
   constexpr uint32_t BCAST_FLAG_BYDHCP = 0x0002;
 
-  /** @brief It signalize that network device interface ip address is
+  /** It signalize that network device interface ip address is
    * temporary. */
   constexpr uint32_t BCAST_FLAG_ISTEMPORARY = 0x0004;
 
-  /** @brief Reserved. */
+  /** Reserved. */
   constexpr uint32_t BCAST_FLAG_WITHPRGTYPE = 0x8000;
 
-  /** @brief Broadcast request packet structure. */
+  /** Broadcast request packet structure. */
   struct BcastRequest
   {
-    /** @brief Default magic number 0x1020EFCF. */
+    /** Default magic number 0x1020EFCF. */
     const uint32_t magic;
-    /** @brief Port to send reply to. */
+    /** Port to send reply to. */
     const uint16_t reply_port;
 
-    /** @brief Unused. */
+    /** Unused. */
     const uint16_t reserved;
 
     BcastRequest()
@@ -67,62 +64,50 @@ namespace ifm3d
     { }
   };
 
-  /** @brief Broadcast reply packet structure. */
+  /** Broadcast reply packet structure. */
   struct BcastReply
   {
-    /** @brief Default magic number 0x19111981. */
+    /** Default magic number 0x19111981. */
     uint32_t magic;
 
-    /** @brief Network device ip address. */
+    /** Network device ip address. */
     uint32_t ip_address;
 
-    /** @brief Network device gateway address. */
+    /** Network device gateway address. */
     uint32_t ip_gateway;
 
-    /** @brief Network device netmask. */
+    /** Network device netmask. */
     uint32_t ip_netmask;
 
-    /** @brief Network device port this is send from. */
+    /** Network device port this is send from. */
     uint16_t port;
 
-    /** @brief Vendor ID */
+    /** Vendor ID */
     uint16_t vendor_id;
 
-    /** @brief Unused. */
+    /** Unused. */
     uint16_t device_id;
 
-    /** @brief Unused. */
+    /** Unused. */
     uint16_t reserved1;
 
-    /** @brief Unused. */
+    /** Unused. */
     uint32_t reserved2;
 
-    /** @brief Unused. */
+    /** Unused. */
     uint32_t reserved3;
 
-    /** @brief Network device interface mac address. */
+    /** Network device interface mac address. */
     uint8_t mac[6];
 
-    /** @brief Network device flags. */
+    /** Network device flags. */
     uint16_t flags;
 
-    /** @brief Network device hostname */
+    /** Network device hostname */
     char name[64];
 
-    /** @brief device name defined by the user */
+    /** @device name defined by the user */
     char devicename[256];
-
-    void
-    NetworktoHost()
-    {
-      ip_address = ntohl(ip_address);
-      ip_gateway = ntohl(ip_gateway);
-      ip_netmask = ntohl(ip_netmask);
-      port = ntohs(port);
-      flags = ntohs(flags);
-      device_id = ntohs(device_id);
-      vendor_id = ntohs(vendor_id);
-    }
   };
 
   namespace
@@ -154,59 +139,94 @@ namespace ifm3d
     }
   }
 
-  struct IFMNetworkDevice
+  IFMNetworkDevice::IFMNetworkDevice(
+    Data& data,
+    const std::string& ip_address_via_interface)
   {
-    const std::string ip_address;
-    const std::string mac;
-    const std::string subnet;
-    const std::string gateway;
-    const uint16_t port;
-    /** @brief the device gives some additional information via those flags */
-    const uint16_t flags;
-    const std::string hostname;
-    /** @brief IP-address of local-interface on which the NetDevice was found
-     */
-    const std::string found_via;
-    const std::string device_name;
-    const uint16_t vendor_id;
-    const uint16_t device_id;
+    BcastReply reply;
+    std::memcpy(&reply, data.data(), sizeof(BcastReply));
 
-    IFMNetworkDevice(const BcastReply& reply, const std::string& interface)
-      : ip_address(address2Str(reply.ip_address)),
-        gateway(address2Str(reply.ip_gateway)),
-        subnet(address2Str(reply.ip_netmask)),
-        mac(uint8Mac2macStr((uint8_t*)reply.mac)),
-        port(reply.port),
-        flags(reply.flags),
-        device_id(reply.device_id),
-        vendor_id(reply.vendor_id),
-        hostname(std::string(reply.name)),
-        device_name(std::string(reply.devicename)),
-        found_via(interface)
-    { }
+    ip_address_ = address2Str(ntohl(reply.ip_address));
+    gateway_ = address2Str(ntohl(reply.ip_gateway));
+    subnet_ = address2Str(ntohl(reply.ip_netmask));
+    mac_ = uint8Mac2macStr((uint8_t*)reply.mac);
+    port_ = ntohs(reply.port);
+    flags_ = ntohs(reply.flags);
+    device_id_ = ntohs(reply.device_id);
+    vendor_id_ = ntohs(reply.vendor_id);
+    hostname_ = std::string(reply.name);
+    device_name_ = std::string(reply.devicename);
+    found_via_ = ip_address_via_interface;
+  }
 
-    void
-    Display()
-    {
-      std::cout << std::endl;
-      std::cout << "ip-address : " << ip_address << std::endl;
-      std::cout << "gateway : " << gateway << std::endl;
-      std::cout << "subnet : " << subnet << std::endl;
-      std::cout << "mac : " << mac << std::endl;
-      std::cout << "port : " << port << std::endl;
-      std::cout << "flags : " << flags << std::endl;
-      std::cout << "device-id : " << device_id << std::endl;
-      std::cout << "vendor_id : " << vendor_id << std::endl;
-      std::cout << "hostname : " << hostname << std::endl;
-      std::cout << "device-name : " << device_name << std::endl;
-      std::cout << "found_via : " << found_via << std::endl;
-    }
-  };
+  std::string
+  IFMNetworkDevice::GetIPAddress() const
+  {
+    return ip_address_;
+  }
+
+  std::string
+  IFMNetworkDevice::GetMACAddress() const
+  {
+    return mac_;
+  }
+
+  std::string
+  IFMNetworkDevice::GetNetmask() const
+  {
+    return subnet_;
+  }
+
+  std::string
+  IFMNetworkDevice::GetGateway() const
+  {
+    return gateway_;
+  }
+
+  uint16_t
+  IFMNetworkDevice::GetPort() const
+  {
+    return port_;
+  }
+
+  uint16_t
+  IFMNetworkDevice::GetFlag() const
+  {
+    return flags_;
+  }
+
+  std::string
+  IFMNetworkDevice::GetHostName() const
+  {
+    return hostname_;
+  }
+
+  std::string
+  IFMNetworkDevice::GetDeviceName() const
+  {
+    return device_name_;
+  }
+
+  uint16_t IFMNetworkDevice::GetVendorId() const
+  {
+    return vendor_id_;
+  }
+
+  uint16_t IFMNetworkDevice::GetDeviceId() const
+  {
+    return device_id_;
+  }
+
+  std::string
+  IFMNetworkDevice::GetFoundVia() const
+  {
+    return found_via_;
+  }
 
   constexpr size_t MAX_UDP_PACKET_SIZE = 65535;
   using Data = std::vector<unsigned char>;
   constexpr size_t TIMEOUT_FOR_EACH_SEARCH_IN_MS = 3000;
-  /*@brief This class provides an interface  for send and receive
+  /* This class provides an interface  for send and receive
    * over UDP socket.
    **/
   class UDPConnection : public std::enable_shared_from_this<UDPConnection>
@@ -214,82 +234,100 @@ namespace ifm3d
   public:
     UDPConnection(asio::io_context& context,
                   asio::ip::udp::endpoint& local_endpoint)
-      : socket(context, local_endpoint),
-        timer(context)
+      : socket_(context),
+        timer_(context)
     {
-      data.resize(MAX_UDP_PACKET_SIZE);
-      socket.set_option(asio::ip::udp::socket::reuse_address(true));
+      socket_.open(asio::ip::udp::v4());
+      data_.resize(MAX_UDP_PACKET_SIZE);
       asio::socket_base::broadcast option(true);
-      socket.set_option(option);
+      socket_.set_option(option);
+      socket_.set_option(asio::ip::udp::socket::reuse_address(true));
+      socket_.bind(local_endpoint);
     }
-    /*@brief sends the data on the endpoint
+
+    /*Sends the data on the endpoint
      *@param data Data to be send on endpoint
      *@param Endpoint to send the data.
      **/
     void
-    Send(const Data& data, asio::ip::udp::endpoint remote_endpoint)
+    Send(const Data& data, asio::ip::udp::endpoint& remote_endpoint)
     {
-      socket.async_send_to(asio::buffer((char*)data.data(), data.size()),
-                           remote_endpoint,
-                           std::bind(&UDPConnection::handle_send,
-                                     this,
-                                     std::placeholders::_1,
-                                     std::placeholders::_2));
+      socket_.async_send_to(asio::buffer((char*)data.data(), data.size()),
+                            remote_endpoint,
+                            std::bind(&UDPConnection::_HandleSend,
+                                      this,
+                                      std::placeholders::_1,
+                                      std::placeholders::_2));
     }
-    /*@brief grab data on the local endpoint till the timeout occur*/
+    /*Grab data on the local endpoint till the timeout occur*/
     void
     GrabData()
     {
-      recieve();
-      check_timeout();
+      _Receive();
+      _CheckTimeout();
     }
 
-    /*@brief provides interface to register callback on data received */
     void
-    RegisterOnRecieve(
+    Close()
+    {
+      socket_.close();
+    }
+
+    /*Provides interface to register callback on data received */
+    void
+    RegisterOnReceive(
       std::function<void(asio::ip::udp::endpoint&, Data, size_t)> on_recvieve)
     {
-      this->on_recieve = on_recvieve;
+      this->on_receive_ = on_recvieve;
     }
 
-    /*@brief provides interface to register callback on timeout or for any error*/
+    /*Provides interface to register callback on timeout or for any
+     * error*/
     void
     RegisterOnClose(
       std::function<void(std::shared_ptr<UDPConnection>)> on_close)
     {
-      this->on_close = on_close;
+      this->on_close_ = on_close;
     }
 
-  protected:
+  private:
     void
-    handle_send(const asio::error_code& error,
+    _HandleSend(const asio::error_code& error,
                 std::size_t /*bytes_transferred*/)
     {
       /* udp we send and forget so nothing to do in this callback*/
     }
 
     void
-    recieve()
+    _Receive()
     {
       /* start the timer for timeout of 3 secs, if data do not come
-         within timeout then connection will be closed and notified to parent */
-      timer.expires_from_now(
+         within timeout then connection will be closed and notified to parent
+       */
+      timer_.expires_from_now(
         std::chrono::milliseconds(TIMEOUT_FOR_EACH_SEARCH_IN_MS));
-      data.clear();
-      data.resize(MAX_UDP_PACKET_SIZE);
+      data_.clear();
+      data_.resize(MAX_UDP_PACKET_SIZE);
 
-      asio::ip::udp::endpoint sender_endpoint;
-      socket.async_receive_from(asio::buffer(data.data(), data.size()),
-                                sender_endpoint,
-                                std::bind(&UDPConnection::handle_receive,
-                                          this,
-                                          socket.local_endpoint(),
-                                          std::placeholders::_1,
-                                          std::placeholders::_2));
+      try
+        {
+          asio::ip::udp::endpoint sender_endpoint;
+          socket_.async_receive_from(asio::buffer(data_.data(), data_.size()),
+                                     sender_endpoint,
+                                     std::bind(&UDPConnection::_HandleReceive,
+                                               this,
+                                               socket_.local_endpoint(),
+                                               std::placeholders::_1,
+                                               std::placeholders::_2));
+        }
+      catch (std::exception& e)
+        {
+          std::cerr << e.what() << std::endl;
+        }
     }
 
     void
-    handle_receive(asio::ip::udp::endpoint& sender,
+    _HandleReceive(asio::ip::udp::endpoint& sender,
                    const asio::error_code& error,
                    size_t bytes_transferred)
     {
@@ -297,38 +335,37 @@ namespace ifm3d
         {
           return;
         }
-      on_recieve(sender, data, bytes_transferred);
-      recieve();
+      on_receive_(sender, data_, bytes_transferred);
+      _Receive();
     }
 
     void
     close()
     {
-      socket.close();
+      socket_.close();
       // notify the caller through registered callback
-      on_close(shared_from_this());
+      on_close_(shared_from_this());
     }
 
     void
-    check_timeout()
+    _CheckTimeout()
     {
-      if (timer.expires_at() <= std::chrono::system_clock::now())
+      if (timer_.expires_at() <= std::chrono::system_clock::now())
         {
           close();
         }
       else
         {
-          timer.async_wait(std::bind(&UDPConnection::check_timeout, this));
+          timer_.async_wait(std::bind(&UDPConnection::_CheckTimeout, this));
         }
     }
 
   private:
-    asio::ip::udp::socket socket;
-    asio::system_timer timer;
-    std::mutex mutex;
-    Data data;
-    std::function<void(asio::ip::udp::endpoint&, Data, size_t)> on_recieve;
-    std::function<void(std::shared_ptr<UDPConnection>)> on_close;
+    asio::ip::udp::socket socket_;
+    asio::system_timer timer_;
+    Data data_;
+    std::function<void(asio::ip::udp::endpoint&, Data, size_t)> on_receive_;
+    std::function<void(std::shared_ptr<UDPConnection>)> on_close_;
   };
 
   const std::map<uint32_t, std::function<size_t(size_t)>> package_validation{
@@ -342,12 +379,12 @@ namespace ifm3d
   class IFMDeviceDiscovery
   {
   public:
-    IFMDeviceDiscovery() : work_guard(asio::make_work_guard(io_context))
+    IFMDeviceDiscovery() : work_guard_(asio::make_work_guard(io_context_))
     {
       for (auto i = 0; i < THREADS_FOR_IO_OPERATIONS; i++)
         {
-          thread_pool.push_back(
-            std::thread(std::bind([&] { io_context.run(); })));
+          thread_pool_.push_back(
+            std::thread(std::bind([&] { io_context_.run(); })));
         }
     }
     IFMDeviceDiscovery(IFMDeviceDiscovery&&) = delete;
@@ -358,76 +395,138 @@ namespace ifm3d
     std::vector<IFMNetworkDevice>
     NetworkSearch()
     {
-      device_list.clear();
-      asio::ip::udp::resolver resolver(io_context);
+      device_list_.clear();
+
+      /* Creating universal listener udp connection */
+      asio::ip::udp::endpoint endpoint(asio::ip::address_v4::any(),
+                                       BCAST_DEFAULT_PORT);
+      auto con = std::make_shared<UDPConnection>(io_context_, endpoint);
+
+      con->RegisterOnReceive(std::bind(&IFMDeviceDiscovery::_OnReceive,
+                                       this,
+                                       std::placeholders::_1,
+                                       std::placeholders::_2,
+                                       std::placeholders::_3));
+      con->RegisterOnClose(std::bind(&IFMDeviceDiscovery::_RemoveConnection,
+                                     this,
+                                     std::placeholders::_1));
+
+      connection_list_.push_back(con);
+
+      try
+        {
+          auto addresses = _GetAllInterfaceAddress();
+
+          /* broadcast ifm discovery request on all interfaces */
+          for (const auto& address : addresses)
+            {
+              _BroadcastOnInterface(address);
+            }
+          /* get the device list  this will block the thread
+             till all NIC are scanned for devices */
+          auto devices = _GetDeviceList();
+
+          /* stop the io_context after getting list */
+          io_context_.stop();
+
+          // wait for all threads to complete
+          for (std::thread& thread : thread_pool_)
+            {
+              if (thread.joinable())
+                {
+                  thread.join();
+                }
+            }
+        }
+      catch (std::exception& e)
+        {
+          std::cerr << e.what() << std::endl;
+        }
+      return device_list_;
+    }
+  private:
+
+    std::vector<std::string>
+    _GetAllInterfaceAddress()
+    {
+      std::vector<std::string> addresses;
+#ifdef __unix__
+      struct ifaddrs *ifap, *ifa;
+      struct sockaddr_in* sa;
+      char* addr;
+
+      getifaddrs(&ifap);
+      for (ifa = ifap; ifa; ifa = ifa->ifa_next)
+        {
+          if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET)
+            {
+              sa = (struct sockaddr_in*)ifa->ifa_addr;
+              addr = inet_ntoa(sa->sin_addr);
+              std::string ip_address = std::string(addr);
+              addresses.push_back(ip_address);
+            }
+        }
+      freeifaddrs(ifap);
+#else
+
+      asio::ip::udp::resolver resolver(io_context_);
       std::string h = asio::ip::host_name();
       auto re_list = resolver.resolve({h, ""});
 
-      /* Create connection on all interfaces */
       for (const auto& re : re_list)
         {
-          asio::ip::udp::endpoint endpoint(
-            asio::ip::address::from_string(
-              re.endpoint().address().to_string()),
-            BCAST_DEFAULT_PORT);
-
-          auto con = std::make_shared<UDPConnection>(io_context, endpoint);
-          con->RegisterOnRecieve(std::bind(&IFMDeviceDiscovery::on_receive,
-                                           this,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2,
-                                           std::placeholders::_3));
-          con->RegisterOnClose(
-            std::bind(&IFMDeviceDiscovery::remove_connection,
-                      this,
-                      std::placeholders::_1));
-
-          connection_list.push_back(con);
+          addresses.push_back(re.endpoint().address().to_string());
         }
-      // broadcast ifm discovery request on all interfaces
-      broadcast();
-      // call getDevice List
-      auto devices = getDeviceList();
-
-      // stop the io_context after getting list
-      io_context.stop();
-
-      // wait for all threads to complete
-      for (std::thread& thread : thread_pool)
-        {
-          if (thread.joinable())
-            {
-              thread.join();
-            }
-        }
-
-      return devices;
+#endif
+      return addresses;
     }
-
-  private:
-    /* @brief broadcast the Bcast request on all interfaces*/
+    /* broadcast the Bcast request on interface*/
     void
-    broadcast()
+    _BroadcastOnInterface(std::string interface_ip)
     {
       const BcastRequest request;
       Data data;
       data.resize(sizeof(BcastRequest));
       std::memcpy(data.data(), &request, sizeof(BcastRequest));
-      // create a broadcast remote endpoints
-      asio::ip::udp::endpoint remote_endpoint =
-        asio::ip::udp::endpoint(asio::ip::address_v4::broadcast(),
+
+      /* create a local endpoints */
+      asio::ip::udp::endpoint local_endpoint =
+        asio::ip::udp::endpoint(asio::ip::address::from_string(interface_ip),
                                 BCAST_DEFAULT_PORT);
-      // send BCAST_REQUEST on all interfaces
-      for (const auto& con : connection_list)
-        {
-          con->Send(data, remote_endpoint);
-        }
+
+      /** getting the netmask of the interface*/
+      auto netmask = asio::ip::address_v4::netmask(
+        asio::ip::address_v4::from_string(interface_ip));
+
+      /**broadcast of the interface*/
+      auto broadcast_address_of_interface =
+        asio::ip::address_v4::broadcast(
+          asio::ip::address_v4::from_string(interface_ip),
+          netmask)
+          .to_string();
+
+      /* create a local broadcast endpoints */
+      asio::ip::udp::endpoint broadcast_endpoint = asio::ip::udp::endpoint(
+        asio::ip::address::from_string(broadcast_address_of_interface),
+        BCAST_DEFAULT_PORT);
+
+      auto con = std::make_shared<UDPConnection>(io_context_, local_endpoint);
+      con->RegisterOnReceive(std::bind(&IFMDeviceDiscovery::_OnReceive,
+                                       this,
+                                       std::placeholders::_1,
+                                       std::placeholders::_2,
+                                       std::placeholders::_3));
+
+      /* send BCAST_REQUEST on all interfaces */
+      con->Send(data, broadcast_endpoint);
+
+      connection_list_.push_back(con);
     }
-    /*@brief checks the data for corresponding request on magic entry. */
+
+    /*Checks the data for corresponding request on magic entry. */
     std::tuple<bool, uint32_t, size_t>
-    is_response_complete(const Data& data, const size_t byte_recv)
+    _IsResponseComplete(const Data& data, const size_t byte_recv)
     {
-      // timer.cancel_one();
       uint32_t magic_value = 0;
       std::memcpy(&magic_value, data.data(), sizeof(uint32_t));
 
@@ -442,14 +541,14 @@ namespace ifm3d
         }
       else
         {
-          /* Todo : use logger*/
-          std::cout << "invalid response packet" << std::endl;
+          std::cerr << "unknown response for discovery" << std::endl;
+          return {};
         }
     }
-    /*@brief Handles the data packet, parse the reply, creates the
-     * IFMBetworkDevice  */
+    /* Handles the data packet, parse the reply, creates the
+     * IFMNetworkDevice */
     void
-    on_receive(asio::ip::udp::endpoint& sender,
+    _OnReceive(asio::ip::udp::endpoint& sender,
                Data data,
                size_t bytes_transferred)
     {
@@ -457,80 +556,57 @@ namespace ifm3d
       size_t required;
       uint32_t magic_value;
       std::tie(iscomplete, magic_value, required) =
-        is_response_complete(data, bytes_transferred);
+        _IsResponseComplete(data, bytes_transferred);
 
       if (iscomplete)
         {
           if (magic_value == BCAST_MAGIC_REPLY)
             {
-              BcastReply reply;
-              std::memcpy(&reply, data.data(), sizeof(BcastReply));
-              reply.NetworktoHost();
-              IFMNetworkDevice ifm_device(reply, sender.address().to_string());
-              std::lock_guard<std::mutex> lock(device_list_lock);
-              device_list.push_back(ifm_device);
+              IFMNetworkDevice ifm_device(data, sender.address().to_string());
+              std::lock_guard<std::mutex> lock(device_list_lock_);
+              device_list_.push_back(ifm_device);
             }
-        }
-      else
-        {
-          std::cout << "discard this packet";
         }
     }
     /* return the discovered device list*/
     std::vector<IFMNetworkDevice>
-    getDeviceList()
+    _GetDeviceList()
     {
-      /* Grab device BCAST_REPLY on all Connections */
-      for (auto con : connection_list)
-        {
-          con->GrabData();
-        }
-
+      /** start grab on universal brodcast socket*/
+      connection_list_[0]->GrabData();
       /*block the main thread till the search is complete
-      which is the condition when all the connection on
-      interface is removed from connection pool */
-      std::unique_lock<std::mutex> lock_to_complete(mutex);
-      cv.wait(lock_to_complete, [&] { return connection_list.size() == 0; });
-      return device_list;
+      which is the condition when all the there is no respone on any interface 
+      for more than  TIMEOUT_FOR_EACH_SEARCH_IN_MS*/
+      std::unique_lock<std::mutex> lock_to_complete(con_mutex_);
+      cv_.wait(lock_to_complete, [&] { return connection_list_.size() == 0; });
+      return device_list_;
     }
 
-    /*@brief remove the connection from the connection list */
+    /* remove the connection from the connection list */
     void
-    remove_connection(std::shared_ptr<UDPConnection> con)
+    _RemoveConnection(std::shared_ptr<UDPConnection> con)
     {
-      std::lock_guard<std::mutex> lock(connection_pool_lock);
-      connection_list.erase(std::remove(std::begin(connection_list),
-                                        std::end(connection_list),
-                                        con),
-                            std::end(connection_list));
-      cv.notify_one();
+      std::lock_guard<std::mutex> lock(con_mutex_);
+      connection_list_.erase(std::remove(std::begin(connection_list_),
+                                         std::end(connection_list_),
+                                         con),
+                             std::end(connection_list_));
+      for (const auto& con : connection_list_)
+        {
+          con->Close();
+        }
+      connection_list_.resize(0);
+      cv_.notify_one();
     }
 
-    asio::io_context io_context;
-    asio::executor_work_guard<asio::io_service::executor_type> work_guard;
-    std::mutex mutex;
-    std::condition_variable cv;
-    std::vector<std::shared_ptr<UDPConnection>> connection_list;
-    std::vector<ifm3d::IFMNetworkDevice> device_list;
-    std::vector<std::thread> thread_pool;
-    std::mutex connection_pool_lock;
-    std::mutex device_list_lock;
+    asio::io_context io_context_;
+    asio::executor_work_guard<asio::io_service::executor_type> work_guard_;
+    std::mutex con_mutex_;
+    std::condition_variable cv_;
+    std::vector<std::shared_ptr<UDPConnection>> connection_list_;
+    std::vector<ifm3d::IFMNetworkDevice> device_list_;
+    std::vector<std::thread> thread_pool_;
+    std::mutex device_list_lock_;
   };
 }
 #endif // IFM3D_CAMERA_DISCOVERY_HPP
-
-/* Sample usage program */
-#if 0
-
-int main()
-{
-  ifm3d::IFMDeviceDiscovery ifm_discovery;
-  auto devices = ifm_discovery.NetworkSearch();
-
-  for (auto & device : devices)
-    {
-      device.Display();
-    }
-}
-
-#endif

--- a/modules/camera/src/libifm3d_camera/discovery.hpp
+++ b/modules/camera/src/libifm3d_camera/discovery.hpp
@@ -1,0 +1,122 @@
+// -*- c++ -*-
+/*
+ * Copyright (C) 2020 ifm electronics, gmbh
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distribted on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IFM3D_CAMERA_DISCOVERY_HPP
+#define IFM3D_CAMERA_DISCOVERY_HPP
+
+#include <asio.hpp>
+#include <vector>
+#include <string>
+#include <tuple>
+#include <iostream>
+#include <iomanip>
+#include <chrono>
+namespace ifm3d
+{
+  /** @brief Broadcast default port. */
+  constexpr uint16_t BCAST_DEFAULT_PORT = 3321;
+
+  /** @brief Broadcast reply magic number. */
+  constexpr uint32_t BCAST_MAGIC_REPLY = 0x19111981;
+
+  /** @brief Broadcast request magic number. */
+  constexpr uint32_t BCAST_MAGIC_REQUEST = 0x1020efcf;
+
+  /** @brief It signalize that network device is not in same subnet. */
+  constexpr uint32_t BCAST_FLAG_WRONGSUBNET = 0x0001;
+
+  /** @brief It signalize that network device interface ip address is set via dhcp. */
+  constexpr uint32_t BCAST_FLAG_BYDHCP = 0x0002;
+
+  /** @brief It signalize that network device interface ip address is temporary. */
+  constexpr uint32_t BCAST_FLAG_ISTEMPORARY = 0x0004;
+
+  /** @brief Reserved. */
+  constexpr uint32_t BCAST_FLAG_WITHPRGTYPE = 0x8000;
+
+
+  /** @brief Broadcast request packet structure. */
+  struct BcastRequest {
+    /** @brief Default magic number 0x1020EFCF. */
+    const uint32_t magic;// = htonl(BCAST_MAGIC_REQUEST);
+
+    /** @brief Port to send reply to. */
+    const uint16_t reply_port;// = htonl(BCAST_DEFAULT_PORT);
+
+    /** @brief Unused. */
+    const uint16_t reserved;
+
+    BcastRequest():magic(htonl(BCAST_MAGIC_REQUEST)), reply_port(htons(BCAST_DEFAULT_PORT)), reserved(0)
+    {}
+  };
+
+  /** @brief Broadcast reply packet structure. */
+ struct BcastReply {
+    /** @brief Default magic number 0x19111981. */
+    uint32_t magic;
+
+    /** @brief Network device ip address. */
+    uint32_t ip_address;
+
+    /** @brief Network device gateway address. */
+    uint32_t ip_gateway;
+
+    /** @brief Network device netmask. */
+    uint32_t ip_netmask;
+
+    /** @brief Network device port this is send from. */
+    uint16_t port;
+
+    /** @brief Vendor ID */
+    uint16_t vendor_id;
+
+    /** @brief Unused. */
+    uint16_t device_id;
+
+    /** @brief Unused. */
+    uint16_t reserved1;
+
+    /** @brief Unused. */
+    uint32_t reserved2;
+
+    /** @brief Unused. */
+    uint32_t reserved3;
+
+    /** @brief Network device interface mac address. */
+    uint8_t  mac[6];
+
+    /** @brief Network device flags. */
+    uint16_t flags;
+
+    /** @brief Network device hostname */
+    char     name[64];
+
+    /** @brief device name defined by the user */
+    char     devicename[256];
+
+    void NetworktoHost()
+    {
+      ip_address = ntohl(ip_address);
+      ip_gateway = ntohl(ip_gateway);
+      ip_netmask = ntohl(ip_netmask);
+      port = ntohs(port);
+      flags = ntohs(flags);
+      device_id = ntohs(device_id);
+      vendor_id = ntohs(vendor_id);
+    }
+ };
+}
+#endif // IFM3D_CAMERA_DISCOVERY_HPP

--- a/modules/tools/include/ifm3d/tools.h
+++ b/modules/tools/include/ifm3d/tools.h
@@ -12,6 +12,7 @@
 #include <ifm3d/tools/cmdline_app.h>
 #include <ifm3d/tools/config_app.h>
 #include <ifm3d/tools/cp_app.h>
+#include <ifm3d/tools/discover_app.h>
 #include <ifm3d/tools/dump_app.h>
 #include <ifm3d/tools/export_app.h>
 #include <ifm3d/tools/imager_types_app.h>

--- a/modules/tools/include/ifm3d/tools.h
+++ b/modules/tools/include/ifm3d/tools.h
@@ -24,6 +24,7 @@
 #include <ifm3d/tools/reboot_app.h>
 #include <ifm3d/tools/reset_app.h>
 #include <ifm3d/tools/rm_app.h>
+#include <ifm3d/tools/set_temp_ip_app.h>
 #include <ifm3d/tools/time_app.h>
 #include <ifm3d/tools/trace_app.h>
 

--- a/modules/tools/include/ifm3d/tools.h
+++ b/modules/tools/include/ifm3d/tools.h
@@ -24,7 +24,6 @@
 #include <ifm3d/tools/reboot_app.h>
 #include <ifm3d/tools/reset_app.h>
 #include <ifm3d/tools/rm_app.h>
-#include <ifm3d/tools/set_temp_ip_app.h>
 #include <ifm3d/tools/time_app.h>
 #include <ifm3d/tools/trace_app.h>
 

--- a/modules/tools/include/ifm3d/tools/discover_app.h
+++ b/modules/tools/include/ifm3d/tools/discover_app.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __IFM3D_TOOLS_DISCOVER_APP_H__
-#define __IFM3D_TOOLS_DISCOVER_APP_H__
+#ifndef IFM3D_TOOLS_DISCOVER_APP_H
+#define IFM3D_TOOLS_DISCOVER_APP_H
 
 #include <string>
 #include <ifm3d/tools/cmdline_app.h>
@@ -13,15 +13,20 @@
 namespace ifm3d
 {
   /**
-   * Concrete implementation of the `discover` subcommand to the `ifm3d` command-line
-   * utility.
+   * Concrete implementation of the `discover` subcommand to the `ifm3d`
+   * command-line utility.
    */
   class DiscoverApp : public ifm3d::CmdLineApp
   {
   public:
-    DiscoverApp(int argc, const char **argv, const std::string& name = "discover");
+    DiscoverApp(int argc,
+                const char** argv,
+                const std::string& name = "discover");
     int Run();
+
+  private:
+    void _LocalHelp() override;
   }; // end: class DiscoverApp
 } // end: namespace ifm3d
 
-#endif // __IFM3D_TOOLS_DISCOVER_APP_H__
+#endif // IFM3D_TOOLS_DISCOVER_APP_H

--- a/modules/tools/include/ifm3d/tools/discover_app.h
+++ b/modules/tools/include/ifm3d/tools/discover_app.h
@@ -1,18 +1,7 @@
 // -*- c++ -*-
 /*
- * Copyright (C) 2020 ifm electronic GmbH
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distribted on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (C) 2020 ifm electronic, gmbh
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #ifndef __IFM3D_TOOLS_DISCOVER_APP_H__

--- a/modules/tools/include/ifm3d/tools/discover_app.h
+++ b/modules/tools/include/ifm3d/tools/discover_app.h
@@ -1,0 +1,38 @@
+// -*- c++ -*-
+/*
+ * Copyright (C) 2020 ifm electronic GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distribted on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __IFM3D_TOOLS_DISCOVER_APP_H__
+#define __IFM3D_TOOLS_DISCOVER_APP_H__
+
+#include <string>
+#include <ifm3d/tools/cmdline_app.h>
+
+namespace ifm3d
+{
+  /**
+   * Concrete implementation of the `discover` subcommand to the `ifm3d` command-line
+   * utility.
+   */
+  class DiscoverApp : public ifm3d::CmdLineApp
+  {
+  public:
+    DiscoverApp(int argc, const char **argv, const std::string& name = "discover");
+    int Run();
+  }; // end: class DiscoverApp
+} // end: namespace ifm3d
+
+#endif // __IFM3D_TOOLS_DISCOVER_APP_H__

--- a/modules/tools/src/libifm3d_tools/cmdline_app.cpp
+++ b/modules/tools/src/libifm3d_tools/cmdline_app.cpp
@@ -81,7 +81,8 @@ These are common commands used in various situations:
     cp            Create a new application on the sensor,
                   bootstrapped from a copy of an existing one.
 
-    discover      Discover ifm devices on the network.
+    discover      Discover ifm devices on the network and can set
+                  temporary ip-address to device.
 
     dump          Serialize the sensor state to JSON.
 

--- a/modules/tools/src/libifm3d_tools/cmdline_app.cpp
+++ b/modules/tools/src/libifm3d_tools/cmdline_app.cpp
@@ -81,6 +81,8 @@ These are common commands used in various situations:
     cp            Create a new application on the sensor,
                   bootstrapped from a copy of an existing one.
 
+    discover      Discover ifm devices on the network.
+
     dump          Serialize the sensor state to JSON.
 
     export        Export an application or whole sensor configuration

--- a/modules/tools/src/libifm3d_tools/discover_app.cpp
+++ b/modules/tools/src/libifm3d_tools/discover_app.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 ifm electronic GmbH
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distribted on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ifm3d/tools/discover_app.h>
+#include <iostream>
+#include <ifm3d/tools/cmdline_app.h>
+#include <ifm3d/camera/camera.h>
+
+ifm3d::DiscoverApp::DiscoverApp(int argc, const char **argv,
+  const std::string& name)
+  : ifm3d::CmdLineApp(argc, argv, name)
+{ }
+
+int ifm3d::DiscoverApp::Run()
+{
+  if (this->vm_.count("help"))
+   {
+     this->_LocalHelp();
+     return 0;
+   }
+
+  auto devices = ifm3d::Camera::DeviceDiscovery();
+
+  for (const auto& device : devices)
+    {
+      auto cam = ifm3d::Camera::MakeShared(device);
+      auto device_type = "";
+      if (cam->IsO3D())
+        {
+          device_type = "O3D";
+        }
+      else if (cam->IsO3X())
+        {
+          device_type = "O3X";
+        }
+      else
+        {
+          continue;
+        }
+      std::cout << device << " (" << device_type << ")" << std::endl;
+    }
+  return 0;
+}

--- a/modules/tools/src/libifm3d_tools/discover_app.cpp
+++ b/modules/tools/src/libifm3d_tools/discover_app.cpp
@@ -8,28 +8,76 @@
 #include <ifm3d/tools/cmdline_app.h>
 #include <ifm3d/camera/camera.h>
 
-ifm3d::DiscoverApp::DiscoverApp(int argc, const char **argv,
-  const std::string& name)
+ifm3d::DiscoverApp::DiscoverApp(int argc,
+                                const char** argv,
+                                const std::string& name)
   : ifm3d::CmdLineApp(argc, argv, name)
-{ }
+{
+  all_opts_ = cxxopts::Options("ifm3d");
 
-int ifm3d::DiscoverApp::Run()
+  // clang-format off
+  this-> all_opts_.add_options("global")
+    ("h,help","Produce this help message and exit");
+  this->all_opts_.add_options(name)
+    ("mac","MAC address of the device",
+     cxxopts::value<std::string>()->default_value(""))
+    ("tempip","IP address",
+     cxxopts::value<std::string>()->default_value(""));
+
+  // clang-format on
+  this->_Parse(argc, argv);
+}
+
+void
+ifm3d::DiscoverApp::_LocalHelp()
+{
+  std::string cmd = "discover";
+  this->all_opts_.custom_help("[<global options>] " + cmd + " [<" + cmd +
+                              " options>]");
+  std::cout << this->all_opts_.help({"global", cmd}) << std::endl;
+}
+
+int
+ifm3d::DiscoverApp::Run()
 {
   if (this->vm_->count("help"))
-   {
-     this->_LocalHelp();
-     return 0;
-   }
+    {
+      this->_LocalHelp();
+      return 0;
+    }
 
-  auto devices = ifm3d::Camera::DeviceDiscovery();
+  auto mac = (*this->vm_)["mac"].as<std::string>();
+  auto temp_ip = (*this->vm_)["tempip"].as<std::string>();
+
+  std::vector<ifm3d::IFMNetworkDevice> devices;
+
+  if (temp_ip == "")
+    {
+      devices = ifm3d::Camera::DeviceDiscovery();
+    }
+  else if (mac != "")
+    {
+      devices = ifm3d::Camera::SetTempIpAddress(mac, temp_ip);
+    }
+  else
+    {
+      std::cout << "mac is needed with tempip" << std::endl;
+      return 0;
+    }
 
   for (const auto& device : devices)
     {
-    #if 1
       try
         {
           auto ip_address = device.GetIPAddress();
-          std::cout << ip_address  << " " << device.GetMACAddress();
+          auto dev_mac = device.GetMACAddress();
+
+          // mac filtering
+          if (mac != "" && mac != dev_mac)
+            {
+              continue;
+            }
+          std::cout << ip_address << " mac = " << dev_mac;
           auto cam = ifm3d::Camera::MakeShared(ip_address);
           auto device_type = "unknown";
           if (cam->IsO3D())
@@ -40,13 +88,12 @@ int ifm3d::DiscoverApp::Run()
             {
               device_type = "O3X";
             }
-            std::cout << " (" << device_type << ")" << std::endl;
-         }
-      catch (std::exception & exp)
-      {
-        // ignore this device and search for next devices..
-      }
-#endif
+          std::cout << " (" << device_type << ")" << std::endl;
+        }
+      catch (std::exception& /*exp */)
+        {
+          // ignore this device and search for next devices..
+        }
     }
   return 0;
 }

--- a/modules/tools/src/libifm3d_tools/discover_app.cpp
+++ b/modules/tools/src/libifm3d_tools/discover_app.cpp
@@ -25,11 +25,13 @@ int ifm3d::DiscoverApp::Run()
 
   for (const auto& device : devices)
     {
+    #if 1
       try
         {
           auto ip_address = device.GetIPAddress();
+          std::cout << ip_address  << " " << device.GetMACAddress();
           auto cam = ifm3d::Camera::MakeShared(ip_address);
-          auto device_type = "";
+          auto device_type = "unknown";
           if (cam->IsO3D())
             {
               device_type = "O3D";
@@ -38,16 +40,13 @@ int ifm3d::DiscoverApp::Run()
             {
               device_type = "O3X";
             }
-          else
-            {
-              continue;
-            }
-            std::cout << ip_address << " (" << device_type << ")" << std::endl;
+            std::cout << " (" << device_type << ")" << std::endl;
          }
       catch (std::exception & exp)
       {
         // ignore this device and search for next devices..
       }
+#endif
     }
   return 0;
 }

--- a/modules/tools/src/libifm3d_tools/discover_app.cpp
+++ b/modules/tools/src/libifm3d_tools/discover_app.cpp
@@ -1,17 +1,6 @@
 /*
- * Copyright (C) 2020 ifm electronic GmbH
- * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distribted on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (C) 2020 ifm electronic, gmbh
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <ifm3d/tools/discover_app.h>
@@ -26,7 +15,7 @@ ifm3d::DiscoverApp::DiscoverApp(int argc, const char **argv,
 
 int ifm3d::DiscoverApp::Run()
 {
-  if (this->vm_.count("help"))
+  if (this->vm_->count("help"))
    {
      this->_LocalHelp();
      return 0;
@@ -36,21 +25,29 @@ int ifm3d::DiscoverApp::Run()
 
   for (const auto& device : devices)
     {
-      auto cam = ifm3d::Camera::MakeShared(device);
-      auto device_type = "";
-      if (cam->IsO3D())
+      try
         {
-          device_type = "O3D";
-        }
-      else if (cam->IsO3X())
-        {
-          device_type = "O3X";
-        }
-      else
-        {
-          continue;
-        }
-      std::cout << device << " (" << device_type << ")" << std::endl;
+          auto ip_address = device.GetIPAddress();
+          auto cam = ifm3d::Camera::MakeShared(ip_address);
+          auto device_type = "";
+          if (cam->IsO3D())
+            {
+              device_type = "O3D";
+            }
+          else if (cam->IsO3X())
+            {
+              device_type = "O3X";
+            }
+          else
+            {
+              continue;
+            }
+            std::cout << ip_address << " (" << device_type << ")" << std::endl;
+         }
+      catch (std::exception & exp)
+      {
+        // ignore this device and search for next devices..
+      }
     }
   return 0;
 }

--- a/modules/tools/src/libifm3d_tools/make_app.cpp
+++ b/modules/tools/src/libifm3d_tools/make_app.cpp
@@ -38,6 +38,11 @@ std::unordered_map<
        return std::make_shared<ifm3d::CpApp>(argc, argv, cmd);
      }},
 
+    {"discover",
+     [](int argc, const char** argv, const std::string& cmd)
+     ->ifm3d::CmdLineApp::Ptr
+     { return std::make_shared<ifm3d::DiscoverApp>(argc, argv, cmd); }},
+
     {"dump",
      [](int argc, const char** argv, const std::string& cmd)
        -> ifm3d::CmdLineApp::Ptr {

--- a/modules/tools/src/libifm3d_tools/make_app.cpp
+++ b/modules/tools/src/libifm3d_tools/make_app.cpp
@@ -40,8 +40,9 @@ std::unordered_map<
 
     {"discover",
      [](int argc, const char** argv, const std::string& cmd)
-     ->ifm3d::CmdLineApp::Ptr
-     { return std::make_shared<ifm3d::DiscoverApp>(argc, argv, cmd); }},
+       -> ifm3d::CmdLineApp::Ptr {
+       return std::make_shared<ifm3d::DiscoverApp>(argc, argv, cmd);
+     }},
 
     {"dump",
      [](int argc, const char** argv, const std::string& cmd)


### PR DESCRIPTION
This PR provides ```discovery``` subcommand in ifm3d tools to search ifm vision devices on network
* Discovery uses udp protocol and broadcast udp packets over network 
* It also provide temporary ip-address change for a device 

