### PR TITLE
reload app while importing when temporal filter is set

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,7 +53,7 @@ jobs:
         git clone --branch 1.33.14-cmake https://github.com/ifm/xmlrpc-c.git
         mkdir xmlrpc-c\build
         cd xmlrpc-c\build
-        cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_INSTALL_PREFIX=c:\deps\install ..
+        cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_INSTALL_PREFIX=c:\deps\install -DBUILD_SHARED_LIBS=ON ..
         cmake --build . --clean-first --config Release --target INSTALL
 
     - name: Build dependency - glog

--- a/.github/workflows/windows_vs2019.yml
+++ b/.github/workflows/windows_vs2019.yml
@@ -58,7 +58,7 @@ jobs:
         git clone --branch 1.33.14-cmake https://github.com/ifm/xmlrpc-c.git
         mkdir xmlrpc-c\build
         cd xmlrpc-c\build
-        cmake -G "Visual Studio 16 2019" -Ax64 -DCMAKE_INSTALL_PREFIX=c:\deps2019\install ..
+        cmake -G "Visual Studio 16 2019" -Ax64 -DCMAKE_INSTALL_PREFIX=c:\deps2019\install -DBUILD_SHARED_LIBS=ON ..
         cmake --build . --clean-first --config Release --target INSTALL
 
     - name: Build dependency - glog

--- a/modules/camera/include/ifm3d/camera/camera.h
+++ b/modules/camera/include/ifm3d/camera/camera.h
@@ -601,6 +601,16 @@ namespace ifm3d
     std::string device_type_;
 
     /**
+     * Return json of an app with given index from camera configuration json.
+     *
+     * @param[in] index Index of application to return
+     * @param[in] j     The current configuration
+     * @param[out] app  Output json of the application when found or empty json
+     * @return          True when application was found
+     */
+    static bool getAppJSON(int index, const json& j, json& app);
+
+    /**
      * Handles parsing a selected sub-tree of a potential input JSON file,
      * setting the parameters as appropriate on the camera, and saving them
      * persistently.

--- a/modules/camera/src/libifm3d_camera/camera.cpp
+++ b/modules/camera/src/libifm3d_camera/camera.cpp
@@ -825,6 +825,28 @@ ifm3d::Camera::FromJSON_(
     }
 }
 
+bool
+ifm3d::Camera::getAppJSON(int index, const json& j, json& app) /*static*/
+{
+  bool app_found = false;
+  app = json({});
+
+  json curr_apps = j["ifm3d"]["Apps"];
+
+  // Just find application with current index
+  for (auto& a : curr_apps)
+    {
+      if (std::stoi(a["Index"].get<std::string>()) == index)
+        {
+          app = a;
+          app_found = true;
+          break;
+        }
+    }
+
+  return (app_found);
+}
+
 void
 ifm3d::Camera::FromJSON(const json& j)
 {
@@ -919,17 +941,7 @@ ifm3d::Camera::FromJSON(const json& j)
             // now in `current` (which is a whole camera dump)
             // we need to find the application at index `idx`.
             json curr_app = json({});
-            json curr_apps = current["ifm3d"]["Apps"];
-            bool app_found = false;
-            for (auto& a : curr_apps)
-              {
-                if (std::stoi(a["Index"].get<std::string>()) == idx)
-                  {
-                    curr_app = a;
-                    app_found = true;
-                    break;
-                  }
-              }
+            bool app_found = getAppJSON(idx, current, curr_app);
 
             if (!app_found)
               {
@@ -972,6 +984,14 @@ ifm3d::Camera::FromJSON(const json& j)
                 j_im.erase("TemporalFilter");
               }
 
+            // When the TemporalFilterType is set for example, there are
+            // additional parameters. They do not exist in the basic
+            // application. When trying to import them, ifm3d will fail. In
+            // case an temporal filter is set, we have to reload the
+            // application.
+            bool reloadApp =
+              (std::stoi(j_im["TemporalFilterType"].get<std::string>()) != 0);
+
             this->FromJSON_(
               curr_app["Imager"],
               j_im,
@@ -985,9 +1005,15 @@ ifm3d::Camera::FromJSON(const json& j)
                     this->pImpl->SetImagerParameter(k, v);
                   }
               },
-              [this]() { this->pImpl->SaveApp(); },
+              [this, j_im]() { this->pImpl->SaveApp(); },
               "Imager",
               idx);
+
+            if (reloadApp)
+              {
+                current = this->ToJSON_(false);
+                app_found = getAppJSON(idx, current, curr_app);
+              }
 
             if (!this->IsO3X())
               {


### PR DESCRIPTION
The parameter "NumberOfImages" only exist when temporal filter is set to
"mean".
Ifm3d compares application to be imported with basically grated
application. So importing fails.
The application has to be imported again from device after imager json
object was imported.