### PR TITLE
Fix some compiler warnings

### DIFF
--- a/modules/common/include/ifm3d/common/logging/log_entry.h
+++ b/modules/common/include/ifm3d/common/logging/log_entry.h
@@ -24,12 +24,12 @@ namespace ifm3d
              const char* file,
              const char* function,
              size_t line)
-      : message_(message),
+      : time_(logging_clock::now()),
         log_level_(log_level),
-        file_(file),
-        func_(function),
+        message_(message),
         line_(line),
-        time_(logging_clock::now())
+        func_(function),
+        file_(file)
     {}
 
     const logging_timepoint&

--- a/modules/device/include/ifm3d/device/err.h
+++ b/modules/device/include/ifm3d/device/err.h
@@ -122,7 +122,7 @@ namespace ifm3d
     /**
      * Exception message
      */
-    virtual const char* what() const noexcept;
+    const char* what() const noexcept override;
 
     /**
      * Accessor to the underlying error code

--- a/modules/device/src/libifm3d_device/discovery.hpp
+++ b/modules/device/src/libifm3d_device/discovery.hpp
@@ -365,7 +365,7 @@ namespace ifm3d
               {
                 shared_this->_CheckTimeout();
               }
-            catch (std::system_error err)
+            catch (const std::system_error &err)
               {
                 if (err.code().category() == asio::system_category() &&
                     err.code().value() == asio::error::bad_descriptor)

--- a/modules/device/src/libifm3d_device/discovery.hpp
+++ b/modules/device/src/libifm3d_device/discovery.hpp
@@ -130,7 +130,7 @@ namespace ifm3d
         ss << std::hex << std::setfill('0') << std::setw(2) << int(value);
       };
 
-      for (int i = 0; i < size - 1; i++)
+      for (size_t i = 0; i + 1 < size; i++)
         {
           converttoHexandAppend(mac[i]);
           ss << "::";
@@ -402,7 +402,7 @@ namespace ifm3d
   public:
     IFMDeviceDiscovery() : work_guard_(asio::make_work_guard(io_context_))
     {
-      for (auto i = 0; i < THREADS_FOR_IO_OPERATIONS; i++)
+      for (unsigned int i = 0; i < THREADS_FOR_IO_OPERATIONS; i++)
         {
           thread_pool_.push_back(
             std::thread(std::bind([&] { io_context_.run(); })));

--- a/modules/framegrabber/src/libifm3d_framegrabber/buffer.cpp
+++ b/modules/framegrabber/src/libifm3d_framegrabber/buffer.cpp
@@ -84,8 +84,8 @@ namespace ifm3d
 
 ifm3d::Buffer::Buffer()
   : data_(nullptr),
-    rows_(0),
     cols_(0),
+    rows_(0),
     nchannel_(0),
     data_size_in_bytes_(0),
     size_(0),

--- a/modules/framegrabber/src/libifm3d_framegrabber/distance_image_info.cpp
+++ b/modules/framegrabber/src/libifm3d_framegrabber/distance_image_info.cpp
@@ -228,10 +228,10 @@ namespace ifm3d
       inverse_intrinsic_calibration(inv_intr_calib),
       u16_distance_buffer(distance_buffer),
       u16_amplitude_buffer(amplitude_buffer),
-      timestamps_nsec(timestamps_nsec),
-      exposure_times_sec(exposure_times_sec),
       width(w),
-      height(h)
+      height(h),
+      timestamps_nsec(timestamps_nsec),
+      exposure_times_sec(exposure_times_sec)
   {}
 
   std::vector<std::uint8_t>

--- a/modules/framegrabber/src/libifm3d_framegrabber/distance_image_info.cpp
+++ b/modules/framegrabber/src/libifm3d_framegrabber/distance_image_info.cpp
@@ -40,7 +40,7 @@ namespace ifm3d
 
     std::vector<std::uint16_t> u16_buffer(npts);
     idx += data_offset;
-    for (auto i = 0; i < npts; ++i)
+    for (std::uint32_t i = 0; i < npts; ++i)
       {
         u16_buffer[i] = ifm3d::mkval<std::uint16_t>(data_buffer.data() + idx);
         idx += UINT16_DATA_SIZE;
@@ -54,7 +54,7 @@ namespace ifm3d
   {
     std::uint32_t data_offset{};
     std::vector<T> t_vector(size);
-    for (auto i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
       {
         t_vector[i] = ifm3d::mkval<T>(data_buffer + data_offset);
         data_offset += sizeof(T);
@@ -67,7 +67,7 @@ namespace ifm3d
   {
     std::uint32_t data_offset{};
     std::vector<float> floatVector(size);
-    for (auto i = 0; i < size; i++)
+    for (std::size_t i = 0; i < size; i++)
       {
         floatVector[i] = ifm3d::mkval<float>(data_buffer + data_offset);
         data_offset += FLOAT_DATA_SIZE;
@@ -249,7 +249,7 @@ namespace ifm3d
     std::vector<uint16_t> dist_u16(npts);
     uint16_t* u16Dist = (uint16_t*)dist_u16.data();
 
-    for (auto i = 0; i < npts; ++i)
+    for (unsigned int i = 0; i < npts; ++i)
       {
         u16Dist[i] = u16_distance_buffer[i];
       }

--- a/modules/framegrabber/src/libifm3d_framegrabber/frame_grabber_impl.hpp
+++ b/modules/framegrabber/src/libifm3d_framegrabber/frame_grabber_impl.hpp
@@ -694,7 +694,7 @@ ifm3d::FrameGrabber::Impl::ImageHandler()
               this->new_frame_callback_(frame);
             }
         }
-      catch (ifm3d::Error ex)
+      catch (const ifm3d::Error &ex)
         {
           // We might get empty frames when we requesting only algo debug but
           // also enable async notifications or async errors, so we just ignore
@@ -707,7 +707,7 @@ ifm3d::FrameGrabber::Impl::ImageHandler()
               LOG_WARNING("Bad image: {}", ex.message());
             }
         }
-      catch (std::exception ex)
+      catch (const std::exception &ex)
         {
           LOG_WARNING("Bad image: {}", ex.what());
         }

--- a/modules/framegrabber/src/libifm3d_framegrabber/frame_grabber_impl.hpp
+++ b/modules/framegrabber/src/libifm3d_framegrabber/frame_grabber_impl.hpp
@@ -177,11 +177,11 @@ ifm3d::FrameGrabber::Impl::Impl(ifm3d::Device::Ptr cam,
     pcic_port_(pcic_port.value_or(ifm3d::DEFAULT_PCIC_PORT)),
     io_service_(),
     sock_(),
+    finish_future_(std::async(std::launch::async, []() {})),
+    is_ready_(false),
     wait_for_frame_future(wait_for_frame_promise.get_future()),
     trigger_feedback_future_(trigger_feedback_promise_.get_future()),
-    ready_future_(ready_promise_.get_future()),
-    finish_future_(std::async(std::launch::async, []() {})),
-    is_ready_(false)
+    ready_future_(ready_promise_.get_future())
 {
   auto device_type = this->cam_->WhoAmI();
   if (device_type == Device::device_family::O3D)

--- a/modules/framegrabber/src/libifm3d_framegrabber/organizer_utils.cpp
+++ b/modules/framegrabber/src/libifm3d_framegrabber/organizer_utils.cpp
@@ -154,7 +154,7 @@ create_xyz_buffer(const std::vector<std::uint8_t>& data,
   int row = -1;
   int xyz_col = 0;
 
-  T* xyz_ptr;
+  T* xyz_ptr = NULL;
   T x_, y_, z_;
 
   constexpr T bad_pixel = 0;

--- a/modules/tools/src/libifm3d_tools/common/fg/jitter_app.cpp
+++ b/modules/tools/src/libifm3d_tools/common/fg/jitter_app.cpp
@@ -105,7 +105,7 @@ mad(const std::vector<T>& arr, T center)
 {
   std::size_t n = arr.size();
   std::vector<T> arr_d(n);
-  for (int i = 0; i < n; ++i)
+  for (std::size_t i = 0; i < n; ++i)
     {
       arr_d[i] = std::abs(arr[i] - center);
     }


### PR DESCRIPTION
Fixed some compiler warnings that have been bugging us in our dependent project.

My goal was to get it to pass with `-Wall`, however:
* The xmlrpc dependency uses `std::auto_ptr` which has been deprecated since C++11 (pointed out by `-Wdeprecated-declarations`).
* `-Wattributes` points out export visibility in class `SWUpdater` which I wasn't sure what to do about.
* Ignoring `-Wunused-variable` and `-Wunused-but-set-variable` in order to not interfer with ongoing development.