### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,15 @@ endif(WIN32)
 
 # Bootstrap gtest
 if(BUILD_TESTS)
-  add_subdirectory(${GTEST_CMAKE_DIR} gtest_bin EXCLUDE_FROM_ALL)
-  add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
+  find_package(ament_cmake_gtest REQUIRED)
+
+   ament_add_gtest(test_logging
+    modules/common/test/logging/ifm3d-common-logging-tests.cpp
+  )
+  target_link_libraries(test_logging
+    ifm3d_common
+  )
+
   add_custom_target(check)
   #var
   if(WIN32)


### PR DESCRIPTION
This pull request fixes the build failure of ifm3d_core on ROS 2 Rolling. The issue was caused by using a hardcoded GTest path (/usr/src/gtest), which is not available on the ROS 2 buildfarm.

I removed the hardcoded path and switched to using ament_cmake_gtest, which is the recommended way to add and run tests in ROS 2. I also added a test target for the existing logging test and linked it with the ifm3d_common module.

