### PR TITLE
Update log.h

### DIFF
--- a/modules/common/include/ifm3d/common/logging/log.h
+++ b/modules/common/include/ifm3d/common/logging/log.h
@@ -27,7 +27,7 @@
 
 namespace ifm3d
 {
-  constexpr const char*
+  inline const char*
   LOG_STRIP_PREFIX(const char* ptr, const char* prefix)
   {
     return ::std::strncmp(ptr, prefix, ::std::strlen(prefix)) == 0 ?


### PR DESCRIPTION
Use inline instead of constexpr to fix gcc 14 compile error

fixes #476 