### PR TITLE
Removed sodium link to Deserialize

### DIFF
--- a/modules/deserialize/CMakeLists.txt
+++ b/modules/deserialize/CMakeLists.txt
@@ -1,6 +1,4 @@
 ifm3d_module(deserialize
-  LINK_LIBRARIES 
-    sodium
   REQUIRED_MODULES
     framegrabber
 )


### PR DESCRIPTION
The build fails when `BUILD_MODULE_DESERIALIZE=ON` and `BUILD_MODULE_CRYPTO=OFF` because then Sodium is not built but Deserialize still links to it. As far as I can see, Deserialize doesn't actually use Sodium.