### PR TITLE
Avoid redefining NOMINMAX

### DIFF
--- a/modules/common/include/ifm3d/common/logging/log_writer_console_colored.h
+++ b/modules/common/include/ifm3d/common/logging/log_writer_console_colored.h
@@ -13,7 +13,9 @@
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN
 #  endif
-#  define NOMINMAX
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
 #  include <windows.h>
 #  undef GetMessage
 #endif


### PR DESCRIPTION
Resolves the compiler warning.