### PR TITLE
Changed compiler guard to os guard

### DIFF
--- a/modules/common/include/ifm3d/common/util.h
+++ b/modules/common/include/ifm3d/common/util.h
@@ -10,7 +10,7 @@
 #include <iostream>
 #include <string>
 
-#if defined(_MSC_VER)
+#ifdef _WIN32
 #  include <io.h>
 #  include <windows.h>
 #  define IFM3D_IS_A_TTY(stream) (!!_isatty(_fileno(stream)))

--- a/modules/framegrabber/src/organizer_utils.cpp
+++ b/modules/framegrabber/src/organizer_utils.cpp
@@ -7,9 +7,9 @@
 #include <ifm3d/fg/buffer.h>
 #include <ifm3d/fg/buffer_id.h>
 #include <unordered_map>
-#if defined(__GNUC__) && !defined(__clang__) && !defined(_MSC_VER)
+#if defined(__GNUC__) && !defined(__clang__) && !defined(_WIN32)
 #  include <bits/endian.h>
-#elif defined(__clang__) && !defined(_MSC_VER)
+#elif defined(__clang__) && !defined(_WIN32)
 #  if __has_include(<bits/endian.h>)
 #    include <bits/endian.h>
 #  endif


### PR DESCRIPTION
I had to make these changes to compile on MSYS gcc which is Windows but not msc. There might be more of this kind in modules I don't use.